### PR TITLE
[STORY] Accept videos on FormDropPicture 

### DIFF
--- a/lib/components/FormDrop.d.ts
+++ b/lib/components/FormDrop.d.ts
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import { ErrorCode } from 'react-dropzone';
+export declare enum FormDropTypes {
+    IMAGE = "image",
+    VIDEO = "video"
+}
+export type FormDropContext = {
+    maxSize: number;
+    recommendedHeight: number;
+    recommendedWidth: number;
+    type: FormDropTypes;
+};
+export type FormDropProps = {
+    name: string;
+    rules?: any;
+    maxSize?: number;
+    recommendedWidth?: number;
+    recommendedHeight?: number;
+    getErrorMessage?: (errorCode: ErrorCode, context: FormDropContext) => string;
+    altLabel?: (context: FormDropContext) => string;
+    deleteLabel?: (context: FormDropContext) => string;
+    helpTextLabel?: (context: FormDropContext) => string;
+    linkLabel?: (context: FormDropContext) => string;
+    label?: (context: FormDropContext) => string;
+    accept?: Record<string, string[]>;
+    type?: FormDropTypes;
+};
+export declare const FormDrop: FC<FormDropProps>;
+export default FormDrop;

--- a/lib/components/FormDrop.js
+++ b/lib/components/FormDrop.js
@@ -3,13 +3,39 @@ import { useDropzone, } from 'react-dropzone';
 import { Controller, useFormContext } from 'react-hook-form';
 import { FormHelperText, Typography, Link, Stack, Button, Box, useTheme, alpha, } from '@mui/material';
 import { Upload } from '@mui/icons-material';
-export const FormDropPicture = (props) => {
+import { megabytesToBytes } from '../utils/bytes';
+export var FormDropTypes;
+(function (FormDropTypes) {
+    FormDropTypes["IMAGE"] = "image";
+    FormDropTypes["VIDEO"] = "video";
+})(FormDropTypes || (FormDropTypes = {}));
+;
+const ACCEPT_BY_TYPE = {
+    [FormDropTypes.IMAGE]: { 'image/png': [], 'image/jpeg': [] },
+    [FormDropTypes.VIDEO]: { 'video/mp4': [] },
+};
+const MAX_SIZE_BY_TYPE = {
+    [FormDropTypes.IMAGE]: megabytesToBytes(100),
+    [FormDropTypes.VIDEO]: megabytesToBytes(150),
+};
+const RECOMMENDED_WIDTH = 900;
+const RECOMMENDED_HEIGHT = 400;
+export const FormDrop = (props) => {
     var _a, _b;
-    const { name, rules, maxSize, recommendedWidth, recommendedHeight, getErrorMessage = () => '', altLabel = '', deleteLabel = '', helpTextLabel = '', linkLabel = '', label = '', accept = { 'image/png': [], 'image/jpeg': [] }, } = props;
+    const { name, rules, maxSize: maxSizeProp, recommendedWidth = RECOMMENDED_WIDTH, recommendedHeight = RECOMMENDED_HEIGHT, getErrorMessage = () => '', altLabel = () => '', deleteLabel = () => '', helpTextLabel = () => '', linkLabel = () => '', label = () => '', accept: acceptProp, type = FormDropTypes.IMAGE, } = props;
     const theme = useTheme();
+    const accept = acceptProp || ACCEPT_BY_TYPE[type];
+    const maxSize = maxSizeProp || MAX_SIZE_BY_TYPE[type];
     const { control, trigger, setError, getFieldState, } = useFormContext();
     const errorMessage = (_b = (_a = getFieldState(name)) === null || _a === void 0 ? void 0 : _a.error) === null || _b === void 0 ? void 0 : _b.message;
     return (_jsx(Controller, { name: name, control: control, rules: rules, render: ({ field: { onChange, value } }) => {
+            var _a;
+            const context = {
+                maxSize,
+                recommendedHeight,
+                recommendedWidth,
+                type,
+            };
             const handleDrop = (files) => {
                 if (!files[0])
                     return;
@@ -27,7 +53,7 @@ export const FormDropPicture = (props) => {
                     return;
                 setError(name, {
                     type: 'custom',
-                    message: getErrorMessage(fileRejections[0].errors[0].code),
+                    message: getErrorMessage(fileRejections[0].errors[0].code, context),
                 });
             };
             const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -38,14 +64,15 @@ export const FormDropPicture = (props) => {
                 multiple: false,
                 maxSize,
             });
-            return (_jsxs(Stack, { spacing: 3, width: "100%", children: [value && (_jsxs(_Fragment, { children: [_jsx(Box, { component: "img", src: value.url || URL.createObjectURL(value.file), alt: altLabel, sx: {
+            const hasValue = ((_a = value === null || value === void 0 ? void 0 : value.url) === null || _a === void 0 ? void 0 : _a.length) > 0 || !!(value === null || value === void 0 ? void 0 : value.file);
+            return (_jsxs(Stack, { spacing: 3, width: "100%", children: [hasValue && (_jsxs(_Fragment, { children: [_jsx(Box, { component: type === FormDropTypes.IMAGE ? "img" : "video", src: value.url || URL.createObjectURL(value.file), alt: altLabel(context), controls: true, sx: {
                                     width: '100%',
                                     height: 'auto',
                                     aspectRatio: `${recommendedWidth}/${recommendedHeight}`,
                                     display: 'block',
                                     objectFit: 'cover',
                                     borderRadius: '20px',
-                                } }), _jsx(Button, { onClick: handleDelete, sx: { width: 'fit-content' }, children: deleteLabel })] })), !value && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
+                                } }), _jsx(Button, { onClick: handleDelete, sx: { width: 'fit-content' }, children: deleteLabel(context) })] })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
                                     borderWidth: '1px',
                                     borderRadius: '20px',
                                     borderColor: theme.palette.divider,
@@ -77,7 +104,7 @@ export const FormDropPicture = (props) => {
                                                 height: '40px',
                                                 color: theme.palette.action.active,
                                             },
-                                        }, children: _jsx(Upload, {}) }), _jsxs(Stack, { spacing: 1, children: [_jsxs(Typography, { variant: "h6", component: "span", children: [_jsx(Link, { color: "primary", children: linkLabel }), label] }), _jsx(Typography, { variant: "body2", component: "span", color: "textSecondary", children: helpTextLabel })] })] })), !!errorMessage && (_jsx(FormHelperText, { error: true, id: "drop-picture-error-text", children: errorMessage }))] }))] }));
+                                        }, children: _jsx(Upload, {}) }), _jsxs(Stack, { spacing: 1, children: [_jsxs(Typography, { variant: "h6", component: "span", children: [_jsx(Link, { color: "primary", children: linkLabel(context) }), label(context)] }), _jsx(Typography, { variant: "body2", component: "span", color: "textSecondary", children: helpTextLabel(context) })] })] })), !!errorMessage && (_jsx(FormHelperText, { error: true, id: "drop-picture-error-text", children: errorMessage }))] }))] }));
         } }));
 };
-export default FormDropPicture;
+export default FormDrop;

--- a/lib/components/FormDropPicture.d.ts
+++ b/lib/components/FormDropPicture.d.ts
@@ -12,6 +12,7 @@ export type FormDropPictureProps = {
     helpTextLabel?: string;
     linkLabel?: string;
     label?: string;
+    accept?: Record<string, string[]>;
 };
 export declare const FormDropPicture: FC<FormDropPictureProps>;
 export default FormDropPicture;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13,7 +13,7 @@ export { default as FormRichEditor } from './components/FormRichEditor';
 export { default as CustomStepper, CustomStepperProps } from './components/CustomStepper';
 export { default as SideStepper } from './components/SideStepper';
 export { default as HorizontalStepper, HorizontalStepperProps, StepType, } from './components/HorizontalStepper';
-export { default as FormDropPicture, FormDropPictureProps, } from './components/FormDropPicture';
+export { default as FormDrop, FormDropProps, FormDropTypes, FormDropContext, } from './components/FormDrop';
 export { default as FormRadioCustomGroup, FormRadioCustomGroupProps, } from './components/FormRadioCustomGroup';
 export { useDebounce } from './hooks/useDebounce';
 export { useServerPagination, TableSortingHeaderProps } from './hooks/useServerPagination';

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ export { default as FormRichEditor } from './components/FormRichEditor';
 export { default as CustomStepper } from './components/CustomStepper';
 export { default as SideStepper } from './components/SideStepper';
 export { default as HorizontalStepper, } from './components/HorizontalStepper';
-export { default as FormDropPicture, } from './components/FormDropPicture';
+export { default as FormDrop, FormDropTypes, } from './components/FormDrop';
 export { default as FormRadioCustomGroup, } from './components/FormRadioCustomGroup';
 export { useDebounce } from './hooks/useDebounce';
 export { useServerPagination } from './hooks/useServerPagination';

--- a/lib/utils/bytes.d.ts
+++ b/lib/utils/bytes.d.ts
@@ -1,0 +1,1 @@
+export declare const megabytesToBytes: (megabytes: number) => number;

--- a/lib/utils/bytes.js
+++ b/lib/utils/bytes.js
@@ -1,0 +1,1 @@
+export const megabytesToBytes = (megabytes) => megabytes * 1024 * 1024;

--- a/src/components/FormDrop.tsx
+++ b/src/components/FormDrop.tsx
@@ -16,37 +16,70 @@ import {
   alpha,
 } from '@mui/material';
 import { Upload } from '@mui/icons-material';
+import { megabytesToBytes } from '../utils/bytes';
 
-export type FormDropPictureProps = {
-  name: string;
-  rules?: any;
-  maxSize: number;
-  recommendedWidth: number;
-  recommendedHeight: number;
-  getErrorMessage?: (errorCode: ErrorCode) => string;
-  altLabel?: string;
-  deleteLabel?: string;
-  helpTextLabel?: string;
-  linkLabel?: string;
-  label?: string;
+export enum FormDropTypes {
+  IMAGE = 'image',
+  VIDEO = 'video',
 };
 
-export const FormDropPicture: FC<FormDropPictureProps> = (props) => {
+const ACCEPT_BY_TYPE = {
+  [FormDropTypes.IMAGE]: { 'image/png': [], 'image/jpeg': [] },
+  [FormDropTypes.VIDEO]: { 'video/mp4': [] },
+};
+
+const MAX_SIZE_BY_TYPE = {
+  [FormDropTypes.IMAGE]: megabytesToBytes(100),
+  [FormDropTypes.VIDEO]: megabytesToBytes(150),
+};
+
+const RECOMMENDED_WIDTH = 900;
+const RECOMMENDED_HEIGHT = 400;
+
+export type FormDropContext = {
+  maxSize: number;
+  recommendedHeight: number;
+  recommendedWidth: number;
+  type: FormDropTypes;
+};
+
+export type FormDropProps = {
+  name: string;
+  rules?: any;
+  maxSize?: number;
+  recommendedWidth?: number;
+  recommendedHeight?: number;
+  getErrorMessage?: (errorCode: ErrorCode, context: FormDropContext) => string;
+  altLabel?: (context: FormDropContext) => string;
+  deleteLabel?: (context: FormDropContext) => string;
+  helpTextLabel?: (context: FormDropContext) => string;
+  linkLabel?: (context: FormDropContext) => string;
+  label?: (context: FormDropContext) => string;
+  accept?: Record<string, string[]>;
+  type?: FormDropTypes;
+};
+
+export const FormDrop: FC<FormDropProps> = (props) => {
   const {
     name,
     rules,
-    maxSize,
-    recommendedWidth,
-    recommendedHeight,
+    maxSize: maxSizeProp,
+    recommendedWidth = RECOMMENDED_WIDTH,
+    recommendedHeight = RECOMMENDED_HEIGHT,
     getErrorMessage = () => '',
-    altLabel = '',
-    deleteLabel = '',
-    helpTextLabel = '',
-    linkLabel = '',
-    label = '',
+    altLabel = () => '',
+    deleteLabel = () => '',
+    helpTextLabel = () => '',
+    linkLabel = () => '',
+    label = () => '',
+    accept: acceptProp,
+    type = FormDropTypes.IMAGE,
   } = props;
 
   const theme = useTheme();
+
+  const accept = acceptProp || ACCEPT_BY_TYPE[type];
+  const maxSize = maxSizeProp || MAX_SIZE_BY_TYPE[type];
 
   const {
     control,
@@ -63,6 +96,13 @@ export const FormDropPicture: FC<FormDropPictureProps> = (props) => {
       control={control}
       rules={rules}
       render={({ field: { onChange, value } }) => {
+        const context = {
+          maxSize,
+          recommendedHeight,
+          recommendedWidth,
+          type,
+        };
+
         const handleDrop = (files: File[]) => {
           if (!files[0]) return;
 
@@ -83,30 +123,36 @@ export const FormDropPicture: FC<FormDropPictureProps> = (props) => {
 
           setError(name, {
             type: 'custom',
-            message: getErrorMessage(fileRejections[0].errors[0].code as ErrorCode),
+            message: getErrorMessage(
+              fileRejections[0].errors[0].code as ErrorCode,
+              context,
+            ),
           });
         };
 
         const { getRootProps, getInputProps, isDragActive } = useDropzone({
           onDrop: handleDrop,
           onDropRejected: handleError,
-          accept: { 'image/png': [], 'image/jpeg': [] },
+          accept,
           maxFiles: 1,
           multiple: false,
           maxSize,
         });
+
+        const hasValue = value?.url?.length > 0 || !!value?.file;
 
         return (
           <Stack
             spacing={3}
             width="100%"
           >
-            {value && (
+            {hasValue && (
               <>
                 <Box
-                  component="img"
+                  component={type === FormDropTypes.IMAGE ? "img" : "video"}
                   src={value.url || URL.createObjectURL(value.file)}
-                  alt={altLabel}
+                  alt={altLabel(context)}
+                  controls
                   sx={{
                     width: '100%',
                     height: 'auto',
@@ -120,11 +166,11 @@ export const FormDropPicture: FC<FormDropPictureProps> = (props) => {
                   onClick={handleDelete}
                   sx={{ width: 'fit-content' }}
                 >
-                  {deleteLabel}
+                  {deleteLabel(context)}
                 </Button>
               </>
             )}
-            {!value && (
+            {!hasValue && (
               <>
                 <Box
                   aria-describedby="drop-picture-error-text"
@@ -175,16 +221,16 @@ export const FormDropPicture: FC<FormDropPictureProps> = (props) => {
                       component="span"
                     >
                       <Link color="primary">
-                        {linkLabel}
+                        {linkLabel(context)}
                       </Link>
-                      {label}
+                      {label(context)}
                     </Typography>
                     <Typography
                       variant="body2"
                       component="span"
                       color="textSecondary"
                     >
-                      {helpTextLabel}
+                      {helpTextLabel(context)}
                     </Typography>
                   </Stack>
                 </Box>
@@ -204,4 +250,4 @@ export const FormDropPicture: FC<FormDropPictureProps> = (props) => {
     />
   );
 };
-export default FormDropPicture;
+export default FormDrop;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,11 @@ export {
   StepType,
 } from './components/HorizontalStepper';
 export {
-  default as FormDropPicture,
-  FormDropPictureProps,
-} from './components/FormDropPicture';
+  default as FormDrop,
+  FormDropProps,
+  FormDropTypes,
+  FormDropContext,
+} from './components/FormDrop';
 export {
   default as FormRadioCustomGroup,
   FormRadioCustomGroupProps,

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,1 @@
+export const megabytesToBytes = (megabytes: number) => megabytes * 1024 * 1024;


### PR DESCRIPTION
## Summary
Cambios realizados:
- Se cambia el componente FormDropPicture a FormDrop.
- Se recibe si se quiere que el FormDrop sea de imagen o video, teniendo
  varias props definidas por default según el tipo. Las mismas se
  permiten sobreescribir.

## Jira Card
[Como administrador quiero agregar un video a mi curso](https://humand.atlassian.net/browse/SQDP-102)