### PR TITLE
[FIX] No mostrar titulo en FormDrop si no existe

### DIFF
--- a/lib/components/DocumentItem.js
+++ b/lib/components/DocumentItem.js
@@ -1,9 +1,25 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { Typography, Link, Stack, Tooltip, IconButton, useTheme, colors, } from '@mui/material';
+import { Typography, Stack, Tooltip, IconButton, Button, useTheme, colors, } from '@mui/material';
 import { Close, PictureAsPdfOutlined, } from '@mui/icons-material';
+import { openFile } from '../utils/files';
 export const DocumentItem = (props) => {
     const { name, size, url, openLabel, deleteLabel, onDelete, } = props;
     const theme = useTheme();
+    const handleOpen = () => __awaiter(void 0, void 0, void 0, function* () {
+        if (!url)
+            return;
+        const blob = yield fetch(url).then((r) => r.blob());
+        openFile(blob);
+    });
     return (_jsxs(Stack, { sx: {
             gap: 2,
             flexDirection: 'row',
@@ -24,6 +40,9 @@ export const DocumentItem = (props) => {
                             flexDirection: 'row',
                             alignItems: 'center',
                             justifyContent: 'center',
-                        }, children: [!!size && (_jsx("span", { children: size })), !!size && !!url && (_jsx("span", { children: "•" })), !!url && (_jsx(Link, { href: url, color: "primary", underline: "none", target: "_blank", rel: "noreferrer", children: openLabel }))] })] }), onDelete && deleteLabel && (_jsx(Tooltip, { title: deleteLabel, children: _jsx(IconButton, { onClick: onDelete, "aria-label": deleteLabel, children: _jsx(Close, { fontSize: "small" }) }) }))] }));
+                        }, children: [!!size && (_jsx("span", { children: size })), !!size && !!url && (_jsx("span", { children: "•" })), !!url && (_jsx(Button, { onClick: handleOpen, color: "primary", variant: "text", size: "small", sx: {
+                                    p: 0,
+                                    m: 0,
+                                }, children: openLabel }))] })] }), onDelete && deleteLabel && (_jsx(Tooltip, { title: deleteLabel, children: _jsx(IconButton, { onClick: onDelete, "aria-label": deleteLabel, children: _jsx(Close, { fontSize: "small" }) }) }))] }));
 };
 export default DocumentItem;

--- a/lib/components/FormDrop.js
+++ b/lib/components/FormDrop.js
@@ -33,7 +33,7 @@ export const FormDrop = (props) => {
     const { control, trigger, setError, getFieldState, } = useFormContext();
     const errorMessage = (_b = (_a = getFieldState(name)) === null || _a === void 0 ? void 0 : _a.error) === null || _b === void 0 ? void 0 : _b.message;
     return (_jsx(Controller, { name: name, control: control, rules: rules, render: ({ field: { onChange, value } }) => {
-            var _a;
+            var _a, _b;
             const dropValue = value;
             const context = {
                 maxSize,
@@ -80,7 +80,7 @@ export const FormDrop = (props) => {
                                     borderRadius: '20px',
                                 } }), _jsx(Button, { onClick: handleDelete, sx: { width: 'fit-content' }, children: deleteLabel(context) })] })), hasValue && type === FormDropTypes.PDF && (_jsx(Stack, { sx: {
                             gap: 1,
-                        }, children: _jsx(DocumentItem, { name: value.file.name, size: sizeLabel(context), url: dropValue.url || (dropValue.file && URL.createObjectURL(dropValue.file)), openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete }) })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
+                        }, children: _jsx(DocumentItem, { name: ((_b = value.file) === null || _b === void 0 ? void 0 : _b.name) || '', size: sizeLabel(context), url: dropValue.url || (dropValue.file && URL.createObjectURL(dropValue.file)), openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete }) })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
                                     borderWidth: '1px',
                                     borderRadius: '20px',
                                     borderColor: theme.palette.divider,

--- a/lib/utils/files.d.ts
+++ b/lib/utils/files.d.ts
@@ -1,0 +1,1 @@
+export declare const openFile: (data: BlobPart) => void;

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -1,0 +1,10 @@
+export const openFile = (data) => {
+    const downloadUrl = window.URL.createObjectURL(new Blob([data]));
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.target = "_blank";
+    link.rel = "noreferrer";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+};

--- a/src/components/DocumentItem.tsx
+++ b/src/components/DocumentItem.tsx
@@ -1,7 +1,6 @@
 import { FC, MouseEvent } from 'react';
 import {
   Typography,
-  Link,
   Stack,
   Tooltip,
   IconButton,
@@ -13,6 +12,7 @@ import {
   Close,
   PictureAsPdfOutlined,
 } from '@mui/icons-material';
+import { openFile } from '../utils/files';
 
 export type DocumentItemProps = {
   name?: string;
@@ -34,6 +34,13 @@ export const DocumentItem: FC<DocumentItemProps> = (props) => {
   } = props;
 
   const theme = useTheme();
+
+  const handleOpen = async () => {
+    if (!url) return;
+
+    const blob = await fetch(url).then((r) => r.blob());
+    openFile(blob);
+  };
 
   return (
     <Stack
@@ -89,15 +96,18 @@ export const DocumentItem: FC<DocumentItemProps> = (props) => {
             </span>
           )}
           {!!url && (
-            <Link
-              href={url}
+            <Button
+              onClick={handleOpen}
               color="primary"
-              underline="none"
-              target="_blank"
-              rel="noreferrer"
+              variant="text"
+              size="small"
+              sx={{
+                p: 0,
+                m: 0,
+              }}
             >
               {openLabel}
-            </Link>
+            </Button>
           )}
         </Stack>
       </Stack>

--- a/src/components/FormDrop.tsx
+++ b/src/components/FormDrop.tsx
@@ -194,7 +194,7 @@ export const FormDrop: FC<FormDropProps> = (props) => {
                 }}
               >
                 <DocumentItem
-                  name={value.file.name}
+                  name={value.file?.name || ''}
                   size={sizeLabel(context)}
                   url={dropValue.url || (dropValue.file && URL.createObjectURL(dropValue.file))}
                   openLabel={openLabel(context)}

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,0 +1,10 @@
+export const openFile = (data: BlobPart) => {
+  const downloadUrl = window.URL.createObjectURL(new Blob([data]));
+  const link = document.createElement('a');
+  link.href = downloadUrl;
+  link.target="_blank";
+  link.rel="noreferrer";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}; 


### PR DESCRIPTION
## Summary
Cambios realizados:
- Si en el componente FormDrop se tiene un archivo de tipo PDF, pero el mismo está como url sin la información del título, el mismo no se muestra.

## Jira Card
[Admin | Como admin quiero editar un curso](https://humand.atlassian.net/browse/SQDP-410)