### PR TITLE
[STORY] Agregar 'disabled' a IconsMenu

### DIFF
--- a/lib/components/IconsMenu.d.ts
+++ b/lib/components/IconsMenu.d.ts
@@ -12,6 +12,7 @@ export type IconsMenuProps = {
     options: Option[];
     onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
     onClose?: (event: MouseEvent) => void;
+    disabled?: boolean;
 };
 export declare const IconsMenu: FC<IconsMenuProps>;
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -8,7 +8,7 @@ export const IconsMenu = (props) => {
     const open = Boolean(anchorEl);
     const disabledStyles = {
         cursor: 'not-allowed',
-        opacity: '38%'
+        opacity: '38%',
     };
     const handleClick = (event) => {
         event.stopPropagation();

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -2,8 +2,8 @@ import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-run
 import { useState } from 'react';
 import { Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
 import { MoreVert as MoreVertIcon } from '@mui/icons-material';
-export const IconsMenu = (props) => {
-    const { options, onClick = () => null, onClose = () => null, disabled = false } = props;
+export const IconsMenu = props => {
+    const { options, onClick = () => null, onClose = () => null, disabled = false, } = props;
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
     const disabledStyles = {

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -2,10 +2,14 @@ import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-run
 import { useState } from 'react';
 import { Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
 import { MoreVert as MoreVertIcon } from '@mui/icons-material';
-export const IconsMenu = props => {
-    const { options, onClick = () => null, onClose = () => null } = props;
+export const IconsMenu = (props) => {
+    const { options, onClick = () => null, onClose = () => null, disabled = false } = props;
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
+    const disabledStyles = {
+        cursor: 'not-allowed',
+        opacity: '38%'
+    };
     const handleClick = (event) => {
         event.stopPropagation();
         setAnchorEl(event.currentTarget);
@@ -21,7 +25,7 @@ export const IconsMenu = props => {
         handleClose(event);
         callback();
     };
-    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { "aria-label": "menu", "aria-controls": "icon-menu", "aria-haspopup": "true", "aria-expanded": open ? 'true' : undefined, id: "button-menu", onClick: handleClick, children: _jsx(MoreVertIcon, {}) }), _jsx(Menu, { id: "icon-menu", anchorEl: anchorEl, open: open, onClose: handleClose, MenuListProps: {
+    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { "aria-label": "menu", "aria-controls": "icon-menu", "aria-haspopup": "true", "aria-expanded": open ? 'true' : undefined, id: "button-menu", onClick: disabled ? undefined : handleClick, disableRipple: disabled, children: _jsx(MoreVertIcon, { sx: disabled ? disabledStyles : undefined }) }), _jsx(Menu, { id: "icon-menu", anchorEl: anchorEl, open: open, onClose: handleClose, MenuListProps: {
                     'aria-labelledby': 'button-menu',
                 }, anchorOrigin: {
                     vertical: 'bottom',

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -26,8 +26,13 @@ export type IconsMenuProps = {
   disabled?: boolean;
 };
 
-export const IconsMenu: FC<IconsMenuProps> = (props) => {
-  const { options, onClick = () => null, onClose = () => null, disabled = false } = props;
+export const IconsMenu: FC<IconsMenuProps> = props => {
+  const {
+    options,
+    onClick = () => null,
+    onClose = () => null,
+    disabled = false,
+  } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -34,7 +34,7 @@ export const IconsMenu: FC<IconsMenuProps> = (props) => {
 
   const disabledStyles = {
     cursor: 'not-allowed',
-    opacity: '38%'
+    opacity: '38%',
   };
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -23,13 +23,19 @@ export type IconsMenuProps = {
   options: Option[];
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onClose?: (event: MouseEvent) => void;
+  disabled?: boolean;
 };
 
-export const IconsMenu: FC<IconsMenuProps> = props => {
-  const { options, onClick = () => null, onClose = () => null } = props;
+export const IconsMenu: FC<IconsMenuProps> = (props) => {
+  const { options, onClick = () => null, onClose = () => null, disabled = false } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
+
+  const disabledStyles = {
+    cursor: 'not-allowed',
+    opacity: '38%'
+  };
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -58,9 +64,10 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
         id="button-menu"
-        onClick={handleClick}
+        onClick={disabled ? undefined : handleClick}
+        disableRipple={disabled}
       >
-        <MoreVertIcon />
+        <MoreVertIcon sx={disabled ? disabledStyles : undefined} />
       </IconButton>
       <Menu
         id="icon-menu"


### PR DESCRIPTION
## Summary

- Se agrega la prop `disabled` al componente IconsMenu junto con lógica para evitar que se abra el menu y estilos para distinguir el estado disabled.

## Screenshots, GIFs or Videos

![icons-menu-disabled](https://github.com/HumandDev/material-hu/assets/160164388/439d37d6-27ed-45cd-b210-c01f4c281ad8)

## Jira Card

https://humand.atlassian.net/browse/SQEG-131