### PR TITLE
[SQDP-610] Abrir pdf de FormDrop

### DIFF
--- a/lib/components/DocumentItem.js
+++ b/lib/components/DocumentItem.js
@@ -1,25 +1,9 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { Typography, Stack, Tooltip, IconButton, Button, useTheme, colors, } from '@mui/material';
+import { Typography, Stack, Tooltip, IconButton, Link, useTheme, colors, } from '@mui/material';
 import { Close, PictureAsPdfOutlined } from '@mui/icons-material';
-import { openFile } from '../utils/files';
 export const DocumentItem = props => {
     const { name, size, url, openLabel, deleteLabel, onDelete } = props;
     const theme = useTheme();
-    const handleOpen = () => __awaiter(void 0, void 0, void 0, function* () {
-        if (!url)
-            return;
-        const blob = yield fetch(url).then(r => r.blob());
-        openFile(blob);
-    });
     return (_jsxs(Stack, { sx: {
             gap: 2,
             flexDirection: 'row',
@@ -40,7 +24,7 @@ export const DocumentItem = props => {
                             flexDirection: 'row',
                             alignItems: 'center',
                             justifyContent: 'center',
-                        }, children: [!!size && _jsx("span", { children: size }), !!size && !!url && _jsx("span", { children: '•' }), !!url && (_jsx(Button, { onClick: handleOpen, color: "primary", variant: "text", size: "small", sx: {
+                        }, children: [!!size && _jsx("span", { children: size }), !!size && !!url && _jsx("span", { children: '•' }), !!url && (_jsx(Link, { href: url, underline: "none", color: "primary", target: "_blank", rel: "noreferrer", sx: {
                                     p: 0,
                                     m: 0,
                                 }, children: openLabel }))] })] }), onDelete && deleteLabel && (_jsx(Tooltip, { title: deleteLabel, children: _jsx(IconButton, { onClick: onDelete, "aria-label": deleteLabel, children: _jsx(Close, { fontSize: "small" }) }) }))] }));

--- a/src/components/DocumentItem.tsx
+++ b/src/components/DocumentItem.tsx
@@ -4,12 +4,11 @@ import {
   Stack,
   Tooltip,
   IconButton,
-  Button,
+  Link,
   useTheme,
   colors,
 } from '@mui/material';
 import { Close, PictureAsPdfOutlined } from '@mui/icons-material';
-import { openFile } from '../utils/files';
 
 export type DocumentItemProps = {
   name?: string;
@@ -24,13 +23,6 @@ export const DocumentItem: FC<DocumentItemProps> = props => {
   const { name, size, url, openLabel, deleteLabel, onDelete } = props;
 
   const theme = useTheme();
-
-  const handleOpen = async () => {
-    if (!url) return;
-
-    const blob = await fetch(url).then(r => r.blob());
-    openFile(blob);
-  };
 
   return (
     <Stack
@@ -76,18 +68,19 @@ export const DocumentItem: FC<DocumentItemProps> = props => {
           {!!size && <span>{size}</span>}
           {!!size && !!url && <span>{'•'}</span>}
           {!!url && (
-            <Button
-              onClick={handleOpen}
+            <Link
+              href={url}
+              underline="none"
               color="primary"
-              variant="text"
-              size="small"
+              target="_blank"
+              rel="noreferrer"
               sx={{
                 p: 0,
                 m: 0,
               }}
             >
               {openLabel}
-            </Button>
+            </Link>
           )}
         </Stack>
       </Stack>


### PR DESCRIPTION
## Summary
Problema:
- Se estaba abriendo los pdfs primero haciendo un fetch a la url y de esta obteniendo el blob, que se usaba para abrirlo con un botón. Esto no funcionaba para Chrome.

Cambios realizados:
- Se cambia el Button por un Link, con la url correspondiente al pdf que se quiere mostrar. El mismo se abre en una pestaña nueva o se descarga según la configuración de cada browser.

## Jira Card
[Detalles de creación y edición de cursos](https://humand.atlassian.net/browse/SQDP-610)