### PR TITLE
[SQDP-644] Memorizar src de FormDrop

### DIFF
--- a/lib/components/FormDrop.js
+++ b/lib/components/FormDrop.js
@@ -1,4 +1,5 @@
 import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
+import { useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Controller, useFormContext } from 'react-hook-form';
 import { FormHelperText, Typography, Link, Stack, Button, Box, useTheme, alpha, } from '@mui/material';
@@ -70,8 +71,13 @@ export const FormDrop = props => {
             });
             const hasValue = (((_a = dropValue === null || dropValue === void 0 ? void 0 : dropValue.url) === null || _a === void 0 ? void 0 : _a.length) && dropValue.url.length > 0) ||
                 !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.file);
-            return (_jsxs(Stack, { spacing: 3, width: "100%", children: [hasValue && type !== FormDropTypes.PDF && (_jsxs(_Fragment, { children: [_jsx(Box, { component: type === FormDropTypes.IMAGE ? 'img' : 'video', src: dropValue.url ||
-                                    (dropValue.file && URL.createObjectURL(dropValue.file)), alt: altLabel(context), controls: true, sx: {
+            const src = useMemo(() => {
+                if (!dropValue)
+                    return undefined;
+                const { url, file } = dropValue;
+                return url || (file && URL.createObjectURL(file));
+            }, [hasValue]);
+            return (_jsxs(Stack, { spacing: 3, width: "100%", children: [hasValue && type !== FormDropTypes.PDF && (_jsxs(_Fragment, { children: [_jsx(Box, { component: type === FormDropTypes.IMAGE ? 'img' : 'video', src: src, alt: altLabel(context), controls: true, sx: {
                                     width: '100%',
                                     height: 'auto',
                                     aspectRatio: `${recommendedWidth}/${recommendedHeight}`,
@@ -80,8 +86,7 @@ export const FormDrop = props => {
                                     borderRadius: '20px',
                                 } }), _jsx(Button, { onClick: handleDelete, sx: { width: 'fit-content' }, children: deleteLabel(context) })] })), hasValue && type === FormDropTypes.PDF && (_jsx(Stack, { sx: {
                             gap: 1,
-                        }, children: _jsx(DocumentItem, { name: ((_b = value.file) === null || _b === void 0 ? void 0 : _b.name) || '', size: sizeLabel(context), url: dropValue.url ||
-                                (dropValue.file && URL.createObjectURL(dropValue.file)), openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete }) })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
+                        }, children: _jsx(DocumentItem, { name: ((_b = value.file) === null || _b === void 0 ? void 0 : _b.name) || '', size: sizeLabel(context), url: src, openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete }) })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
                                     borderWidth: '1px',
                                     borderRadius: '20px',
                                     borderColor: theme.palette.divider,

--- a/src/components/FormDrop.tsx
+++ b/src/components/FormDrop.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useDropzone, ErrorCode, FileRejection } from 'react-dropzone';
 import { Controller, useFormContext } from 'react-hook-form';
 import {
@@ -149,6 +149,17 @@ export const FormDrop: FC<FormDropProps> = props => {
           (dropValue?.url?.length && dropValue.url.length > 0) ||
           !!dropValue?.file;
 
+        const src = useMemo(
+          () => {
+            if (!dropValue) return undefined;
+
+            const { url, file } = dropValue;
+
+            return url || (file && URL.createObjectURL(file));
+          },
+          [hasValue],
+        );
+
         return (
           <Stack
             spacing={3}
@@ -158,10 +169,7 @@ export const FormDrop: FC<FormDropProps> = props => {
               <>
                 <Box
                   component={type === FormDropTypes.IMAGE ? 'img' : 'video'}
-                  src={
-                    dropValue.url ||
-                    (dropValue.file && URL.createObjectURL(dropValue.file))
-                  }
+                  src={src}
                   alt={altLabel(context)}
                   controls
                   sx={{
@@ -190,10 +198,7 @@ export const FormDrop: FC<FormDropProps> = props => {
                 <DocumentItem
                   name={value.file?.name || ''}
                   size={sizeLabel(context)}
-                  url={
-                    dropValue.url ||
-                    (dropValue.file && URL.createObjectURL(dropValue.file))
-                  }
+                  url={src}
                   openLabel={openLabel(context)}
                   deleteLabel={deleteLabel(context)}
                   onDelete={handleDelete}


### PR DESCRIPTION
## Summary
Problema:
- En el componente `FormDrop` se estaba carculando el `src` de la imagen/video/archivo repetidamente, lo que hacía que, en el caso donde se usaba el `URL.createObjectUrl(file)`, se obtenga un `src` diferente en cada render. Esto hacía que los videos tengan un glitch.

Cambios realizados:
- Se agrega un `useMemo` para el `src` en `FormDrop`.

## Screenshots, GIFs or Videos


## Jira Card
[Si subi un video desde mis archivos y después cambio el título, se ve mal el preview del video](https://humand.atlassian.net/browse/SQDP-644)