### PR TITLE
[SQDP-719] Courses | Add file type to FormDrop

### DIFF
--- a/lib/components/DocumentItem.d.ts
+++ b/lib/components/DocumentItem.d.ts
@@ -1,4 +1,8 @@
 import { FC, MouseEvent } from 'react';
+export declare enum DocumentItemTypes {
+    PDF = "pdf",
+    FILE = "file"
+}
 export type DocumentItemProps = {
     name?: string;
     size?: string;
@@ -6,6 +10,7 @@ export type DocumentItemProps = {
     openLabel?: string;
     deleteLabel?: string;
     onDelete?: (event: MouseEvent<HTMLButtonElement>) => void;
+    type?: DocumentItemTypes;
 };
 export declare const DocumentItem: FC<DocumentItemProps>;
 export default DocumentItem;

--- a/lib/components/DocumentItem.js
+++ b/lib/components/DocumentItem.js
@@ -1,9 +1,19 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Typography, Stack, Tooltip, IconButton, Link, useTheme, colors, } from '@mui/material';
-import { Close, PictureAsPdfOutlined } from '@mui/icons-material';
+import { Close, PictureAsPdfOutlined, FolderZipOutlined, } from '@mui/icons-material';
+export var DocumentItemTypes;
+(function (DocumentItemTypes) {
+    DocumentItemTypes["PDF"] = "pdf";
+    DocumentItemTypes["FILE"] = "file";
+})(DocumentItemTypes || (DocumentItemTypes = {}));
+const DOCUMENT_ICONS = {
+    [DocumentItemTypes.PDF]: PictureAsPdfOutlined,
+    [DocumentItemTypes.FILE]: FolderZipOutlined,
+};
 export const DocumentItem = props => {
-    const { name, size, url, openLabel, deleteLabel, onDelete } = props;
+    const { name, size, url, openLabel, deleteLabel, onDelete, type = DocumentItemTypes.FILE, } = props;
     const theme = useTheme();
+    const Icon = DOCUMENT_ICONS[type];
     return (_jsxs(Stack, { sx: {
             gap: 2,
             flexDirection: 'row',
@@ -12,7 +22,7 @@ export const DocumentItem = props => {
             px: 2,
             borderRadius: theme.spacing(1),
             backgroundColor: colors.grey[100],
-        }, children: [_jsx(PictureAsPdfOutlined, { color: "primary", sx: {
+        }, children: [_jsx(Icon, { color: "primary", sx: {
                     width: theme.spacing(5),
                     height: theme.spacing(5),
                 } }), _jsxs(Stack, { sx: {

--- a/lib/components/FormDrop.d.ts
+++ b/lib/components/FormDrop.d.ts
@@ -3,7 +3,8 @@ import { ErrorCode } from 'react-dropzone';
 export declare enum FormDropTypes {
     IMAGE = "image",
     VIDEO = "video",
-    PDF = "pdf"
+    PDF = "pdf",
+    FILE = "file"
 }
 export type FormDropValue = {
     url?: string | null;

--- a/lib/components/FormDrop.js
+++ b/lib/components/FormDrop.js
@@ -6,23 +6,27 @@ import { FormHelperText, Typography, Link, Stack, Button, Box, useTheme, alpha, 
 import { Upload } from '@mui/icons-material';
 import { useModal } from '../hooks/useModal';
 import { CroppingModal } from './CroppingModal';
-import DocumentItem from './DocumentItem';
+import { DocumentItem, DocumentItemTypes } from './DocumentItem';
 import { megabytesToBytes } from '../utils/bytes';
 export var FormDropTypes;
 (function (FormDropTypes) {
     FormDropTypes["IMAGE"] = "image";
     FormDropTypes["VIDEO"] = "video";
     FormDropTypes["PDF"] = "pdf";
+    FormDropTypes["FILE"] = "file";
 })(FormDropTypes || (FormDropTypes = {}));
+const DOCUMENT_TYPES = [FormDropTypes.PDF, FormDropTypes.FILE];
 const ACCEPT_BY_TYPE = {
     [FormDropTypes.IMAGE]: { 'image/png': [], 'image/jpeg': [] },
     [FormDropTypes.VIDEO]: { 'video/mp4': [] },
     [FormDropTypes.PDF]: { 'application/pdf': [] },
+    [FormDropTypes.FILE]: { '*': [] },
 };
 const MAX_SIZE_BY_TYPE = {
     [FormDropTypes.IMAGE]: megabytesToBytes(100),
     [FormDropTypes.VIDEO]: megabytesToBytes(150),
     [FormDropTypes.PDF]: megabytesToBytes(100),
+    [FormDropTypes.FILE]: megabytesToBytes(100),
 };
 const RECOMMENDED_WIDTH = 900;
 const RECOMMENDED_HEIGHT = 400;
@@ -100,16 +104,18 @@ export const FormDrop = props => {
                 const { url, file } = dropValue;
                 return url || (file && URL.createObjectURL(file));
             }, [hasValue]);
-            return (_jsxs(Stack, { spacing: 3, width: "100%", children: [type === FormDropTypes.IMAGE && withCrop && croppingModal, hasValue && type !== FormDropTypes.PDF && (_jsxs(_Fragment, { children: [_jsx(Box, { component: type === FormDropTypes.IMAGE ? 'img' : 'video', src: src, alt: altLabel(context), controls: true, sx: {
+            return (_jsxs(Stack, { spacing: 3, width: "100%", children: [type === FormDropTypes.IMAGE && withCrop && croppingModal, hasValue && !DOCUMENT_TYPES.includes(type) && (_jsxs(_Fragment, { children: [_jsx(Box, { component: type === FormDropTypes.IMAGE ? 'img' : 'video', src: src, alt: altLabel(context), controls: true, sx: {
                                     width: '100%',
                                     height: 'auto',
                                     aspectRatio: `${recommendedWidth}/${recommendedHeight}`,
                                     display: 'block',
                                     objectFit: 'cover',
                                     borderRadius: '20px',
-                                } }), _jsx(Button, { onClick: handleDelete, sx: { width: 'fit-content' }, children: deleteLabel(context) })] })), hasValue && type === FormDropTypes.PDF && (_jsx(Stack, { sx: {
+                                } }), _jsx(Button, { onClick: handleDelete, sx: { width: 'fit-content' }, children: deleteLabel(context) })] })), hasValue && DOCUMENT_TYPES.includes(type) && (_jsx(Stack, { sx: {
                             gap: 1,
-                        }, children: _jsx(DocumentItem, { name: ((_b = value.file) === null || _b === void 0 ? void 0 : _b.name) || '', size: sizeLabel(context), url: src, openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete }) })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
+                        }, children: _jsx(DocumentItem, { name: ((_b = value.file) === null || _b === void 0 ? void 0 : _b.name) || '', size: sizeLabel(context), url: src, openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete, type: type === FormDropTypes.PDF
+                                ? DocumentItemTypes.PDF
+                                : DocumentItemTypes.FILE }) })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
                                     borderWidth: '1px',
                                     borderRadius: '20px',
                                     borderColor: theme.palette.divider,

--- a/src/components/DocumentItem.tsx
+++ b/src/components/DocumentItem.tsx
@@ -8,7 +8,21 @@ import {
   useTheme,
   colors,
 } from '@mui/material';
-import { Close, PictureAsPdfOutlined } from '@mui/icons-material';
+import {
+  Close,
+  PictureAsPdfOutlined,
+  FolderZipOutlined,
+} from '@mui/icons-material';
+
+export enum DocumentItemTypes {
+  PDF = 'pdf',
+  FILE = 'file',
+}
+
+const DOCUMENT_ICONS = {
+  [DocumentItemTypes.PDF]: PictureAsPdfOutlined,
+  [DocumentItemTypes.FILE]: FolderZipOutlined,
+};
 
 export type DocumentItemProps = {
   name?: string;
@@ -17,12 +31,23 @@ export type DocumentItemProps = {
   openLabel?: string;
   deleteLabel?: string;
   onDelete?: (event: MouseEvent<HTMLButtonElement>) => void;
+  type?: DocumentItemTypes;
 };
 
 export const DocumentItem: FC<DocumentItemProps> = props => {
-  const { name, size, url, openLabel, deleteLabel, onDelete } = props;
+  const {
+    name,
+    size,
+    url,
+    openLabel,
+    deleteLabel,
+    onDelete,
+    type = DocumentItemTypes.FILE,
+  } = props;
 
   const theme = useTheme();
+
+  const Icon = DOCUMENT_ICONS[type];
 
   return (
     <Stack
@@ -36,7 +61,7 @@ export const DocumentItem: FC<DocumentItemProps> = props => {
         backgroundColor: colors.grey[100],
       }}
     >
-      <PictureAsPdfOutlined
+      <Icon
         color="primary"
         sx={{
           width: theme.spacing(5),

--- a/src/components/FormDrop.tsx
+++ b/src/components/FormDrop.tsx
@@ -14,25 +14,30 @@ import {
 import { Upload } from '@mui/icons-material';
 import { useModal } from '../hooks/useModal';
 import { CroppingModal, CroppingModalProps } from './CroppingModal';
-import DocumentItem from './DocumentItem';
+import { DocumentItem, DocumentItemTypes } from './DocumentItem';
 import { megabytesToBytes } from '../utils/bytes';
 
 export enum FormDropTypes {
   IMAGE = 'image',
   VIDEO = 'video',
   PDF = 'pdf',
+  FILE = 'file',
 }
+
+const DOCUMENT_TYPES = [FormDropTypes.PDF, FormDropTypes.FILE];
 
 const ACCEPT_BY_TYPE = {
   [FormDropTypes.IMAGE]: { 'image/png': [], 'image/jpeg': [] },
   [FormDropTypes.VIDEO]: { 'video/mp4': [] },
   [FormDropTypes.PDF]: { 'application/pdf': [] },
+  [FormDropTypes.FILE]: { '*': [] },
 };
 
 const MAX_SIZE_BY_TYPE = {
   [FormDropTypes.IMAGE]: megabytesToBytes(100),
   [FormDropTypes.VIDEO]: megabytesToBytes(150),
   [FormDropTypes.PDF]: megabytesToBytes(100),
+  [FormDropTypes.FILE]: megabytesToBytes(100),
 };
 
 const RECOMMENDED_WIDTH = 900;
@@ -206,7 +211,7 @@ export const FormDrop: FC<FormDropProps> = props => {
             width="100%"
           >
             {type === FormDropTypes.IMAGE && withCrop && croppingModal}
-            {hasValue && type !== FormDropTypes.PDF && (
+            {hasValue && !DOCUMENT_TYPES.includes(type) && (
               <>
                 <Box
                   component={type === FormDropTypes.IMAGE ? 'img' : 'video'}
@@ -230,7 +235,7 @@ export const FormDrop: FC<FormDropProps> = props => {
                 </Button>
               </>
             )}
-            {hasValue && type === FormDropTypes.PDF && (
+            {hasValue && DOCUMENT_TYPES.includes(type) && (
               <Stack
                 sx={{
                   gap: 1,
@@ -243,6 +248,11 @@ export const FormDrop: FC<FormDropProps> = props => {
                   openLabel={openLabel(context)}
                   deleteLabel={deleteLabel(context)}
                   onDelete={handleDelete}
+                  type={
+                    type === FormDropTypes.PDF
+                      ? DocumentItemTypes.PDF
+                      : DocumentItemTypes.FILE
+                  }
                 />
               </Stack>
             )}


### PR DESCRIPTION

## Summary
- Se agrega el tipo 'FILE' al componente `FormDrop`, el cuál acepta cualquier tipo de archivo.

## Jira Card
[Trainings - back & admin | Poder agregar una lección del tipo scorm](https://humand.atlassian.net/browse/SQDP-719)