### PR TITLE
NewModal | Permitir un parametro en el onClose

### DIFF
--- a/lib/components/NewModal.d.ts
+++ b/lib/components/NewModal.d.ts
@@ -7,7 +7,7 @@ type Props = {
     textBody?: string;
     primaryButtonProps?: ButtonProps;
     secondaryButtonProps?: ButtonProps;
-    onClose?: () => void;
+    onClose?: (e?: any) => void;
     TitleIcon?: SvgIconComponent;
 };
 declare const NewModal: ({ title, body, textBody, TitleIcon, primaryButtonProps, secondaryButtonProps, onClose, }: Props) => import("react/jsx-runtime").JSX.Element;

--- a/src/components/NewModal.tsx
+++ b/src/components/NewModal.tsx
@@ -23,7 +23,7 @@ type Props = {
   textBody?: string;
   primaryButtonProps?: ButtonProps;
   secondaryButtonProps?: ButtonProps;
-  onClose?: () => void;
+  onClose?: (e?: any) => void;
   TitleIcon?: SvgIconComponent;
 };
 


### PR DESCRIPTION
## Summary
Se agrega (e?) => en el onClose para poder handlear un stopPropagation y evitar que al cerrar el dialog se clickee algo detras.