### PR TITLE
IconsMenu | Actualizar componente a nuevo estilo (pre DS3)

### DIFF
--- a/lib/components/IconsMenu.d.ts
+++ b/lib/components/IconsMenu.d.ts
@@ -15,7 +15,7 @@ export type IconsMenuProps = {
     onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
     onClose?: (event: MouseEvent) => void;
     disabled?: boolean;
-    chevron?: boolean;
+    arrow?: boolean;
 };
 export declare const IconsMenu: FC<IconsMenuProps>;
 export default IconsMenu;

--- a/lib/components/IconsMenu.d.ts
+++ b/lib/components/IconsMenu.d.ts
@@ -8,7 +8,6 @@ export type Option = {
     textProps?: SxProps;
     color?: string;
     disabled?: boolean;
-    arrow?: boolean;
 };
 export type IconsMenuProps = {
     options: Option[];

--- a/lib/components/IconsMenu.d.ts
+++ b/lib/components/IconsMenu.d.ts
@@ -8,12 +8,14 @@ export type Option = {
     textProps?: SxProps;
     color?: string;
     disabled?: boolean;
+    arrow?: boolean;
 };
 export type IconsMenuProps = {
     options: Option[];
     onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
     onClose?: (event: MouseEvent) => void;
     disabled?: boolean;
+    chevron?: boolean;
 };
 export declare const IconsMenu: FC<IconsMenuProps>;
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -33,18 +33,25 @@ export const IconsMenu = props => {
                 }, transformOrigin: {
                     vertical: 'top',
                     horizontal: 'right',
-                }, children: options.map(option => (_jsxs("div", { children: [_jsxs(MenuItem, { onClick: handleOptionClick(option.onClick), disabled: option.disabled, children: [option.icon && (_jsx(ListItemIcon, { sx: {
+                }, children: options.map(option => (_jsxs("div", { children: [_jsxs(MenuItem, { onClick: handleOptionClick(option.onClick), disabled: option.disabled, sx: {
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                                display: 'flex',
+                                pr: 0,
+                            }, children: [option.icon && (_jsx(ListItemIcon, { sx: {
                                         '&>*': {
                                             color: option.disabled ? 'text.disabled' : option.color,
+                                            minWidth: 0,
                                         },
                                     }, children: _jsx(Avatar, { sx: {
                                             bgcolor: option.disabled ? 'grey.300' : 'grey.200',
+                                            color: 'grey.700',
                                             width: 24,
                                             height: 24,
                                         }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
-                                        minWidth: 'auto',
-                                        marginLeft: 'auto',
                                         color: option.disabled ? 'text.disabled' : 'inherit',
+                                        minWidth: 0,
+                                        mr: 0,
                                     }, children: _jsx(ChevronRight, {}) }))] }), option.divider && _jsx(Divider, { sx: { px: 1 } })] }, option.label))) })] }));
 };
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -45,10 +45,10 @@ export const IconsMenu = props => {
                                         },
                                     }, children: _jsx(Avatar, { sx: {
                                             bgcolor: option.disabled ? 'grey.300' : 'grey.200',
-                                            color: 'black',
+                                            color: 'grey.700',
                                             width: 24,
                                             height: 24,
-                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
+                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { mr: 1, color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
                                         color: option.disabled ? 'text.disabled' : 'inherit',
                                         minWidth: 0,
                                         marginRight: 0,

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -1,9 +1,9 @@
 import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
 import { useState } from 'react';
-import { Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
-import { MoreVert as MoreVertIcon } from '@mui/icons-material';
+import { Avatar, Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
+import { ChevronRight, MoreVert as MoreVertIcon } from '@mui/icons-material';
 export const IconsMenu = props => {
-    const { options, onClick = () => null, onClose = () => null, disabled = false, } = props;
+    const { options, onClick = () => null, onClose = () => null, disabled = false, chevron = false, } = props;
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
     const disabledStyles = {
@@ -37,6 +37,14 @@ export const IconsMenu = props => {
                                         '&>*': {
                                             color: option.disabled ? 'text.disabled' : option.color,
                                         },
-                                    }, children: option.icon })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label })] }), option.divider && _jsx(Divider, {})] }, option.label))) })] }));
+                                    }, children: _jsx(Avatar, { sx: {
+                                            bgcolor: option.disabled ? 'grey.300' : 'grey.200',
+                                            width: 24,
+                                            height: 24,
+                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), chevron && (_jsx(ListItemIcon, { sx: {
+                                        minWidth: 'auto',
+                                        marginLeft: 'auto',
+                                        color: option.disabled ? 'text.disabled' : 'inherit',
+                                    }, children: _jsx(ChevronRight, {}) }))] }), option.divider && _jsx(Divider, { sx: { px: 1 } })] }, option.label))) })] }));
 };
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
 import { useState } from 'react';
 import { Avatar, Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
-import { ChevronRight, MoreVert as MoreVertIcon } from '@mui/icons-material';
+import { ChevronRight as ChevronRightIcon, MoreVert as MoreVertIcon, } from '@mui/icons-material';
 export const IconsMenu = props => {
     const { options, onClick = () => null, onClose = () => null, disabled = false, arrow = false, } = props;
     const [anchorEl, setAnchorEl] = useState(null);
@@ -54,6 +54,6 @@ export const IconsMenu = props => {
                                         marginRight: 0,
                                         marginLeft: 0,
                                         fontWeight: 600,
-                                    }, children: _jsx(ChevronRight, {}) }))] }), option.divider && _jsx(Divider, { sx: { mx: 1 } })] }, option.label))) })] }));
+                                    }, children: _jsx(ChevronRightIcon, {}) }))] }), option.divider && _jsx(Divider, { sx: { mx: 1 } })] }, option.label))) })] }));
 };
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -48,10 +48,10 @@ export const IconsMenu = props => {
                                             color: 'grey.700',
                                             width: 24,
                                             height: 24,
-                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
+                                        }, children: option.icon }) })), _jsxs(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: [option.label, " test"] }), arrow && (_jsx(ListItemIcon, { sx: {
                                         color: option.disabled ? 'text.disabled' : 'inherit',
                                         minWidth: 0,
                                         mr: 0,
-                                    }, children: _jsx(ChevronRight, {}) }))] }), option.divider && _jsx(Divider, { sx: { px: 1 } })] }, option.label))) })] }));
+                                    }, children: _jsx(ChevronRight, {}) }))] }), option.divider && _jsx(Divider, { sx: { mx: 1 } })] }, option.label))) })] }));
 };
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -44,7 +44,7 @@ export const IconsMenu = props => {
                                             minWidth: 0,
                                         },
                                     }, children: _jsx(Avatar, { sx: {
-                                            bgcolor: option.disabled ? 'grey.300' : 'grey.200',
+                                            bgcolor: option.disabled ? 'grey.200' : 'grey.100',
                                             color: 'grey.700',
                                             width: 24,
                                             height: 24,

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -38,7 +38,7 @@ export const IconsMenu = props => {
                                 alignItems: 'center',
                                 display: 'flex',
                                 pr: 0,
-                            }, children: [false && option.icon && (_jsx(ListItemIcon, { sx: {
+                            }, children: [option.icon && (_jsx(ListItemIcon, { sx: {
                                         '&>*': {
                                             color: option.disabled ? 'text.disabled' : option.color,
                                             minWidth: 0,
@@ -48,11 +48,12 @@ export const IconsMenu = props => {
                                             color: 'black',
                                             width: 24,
                                             height: 24,
-                                        }, children: option.icon }) })), _jsxs(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: [option.label, " test"] }), arrow && (_jsx(ListItemIcon, { sx: {
+                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
                                         color: option.disabled ? 'text.disabled' : 'inherit',
                                         minWidth: 0,
                                         marginRight: 0,
                                         marginLeft: 0,
+                                        fontWeight: 600,
                                     }, children: _jsx(ChevronRight, {}) }))] }), option.divider && _jsx(Divider, { sx: { mx: 1 } })] }, option.label))) })] }));
 };
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -38,20 +38,21 @@ export const IconsMenu = props => {
                                 alignItems: 'center',
                                 display: 'flex',
                                 pr: 0,
-                            }, children: [option.icon && (_jsx(ListItemIcon, { sx: {
+                            }, children: [false && option.icon && (_jsx(ListItemIcon, { sx: {
                                         '&>*': {
                                             color: option.disabled ? 'text.disabled' : option.color,
                                             minWidth: 0,
                                         },
                                     }, children: _jsx(Avatar, { sx: {
                                             bgcolor: option.disabled ? 'grey.300' : 'grey.200',
-                                            color: 'grey.700',
+                                            color: 'black',
                                             width: 24,
                                             height: 24,
                                         }, children: option.icon }) })), _jsxs(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: [option.label, " test"] }), arrow && (_jsx(ListItemIcon, { sx: {
                                         color: option.disabled ? 'text.disabled' : 'inherit',
                                         minWidth: 0,
-                                        mr: 0,
+                                        marginRight: 0,
+                                        marginLeft: 0,
                                     }, children: _jsx(ChevronRight, {}) }))] }), option.divider && _jsx(Divider, { sx: { mx: 1 } })] }, option.label))) })] }));
 };
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Avatar, Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
 import { ChevronRight, MoreVert as MoreVertIcon } from '@mui/icons-material';
 export const IconsMenu = props => {
-    const { options, onClick = () => null, onClose = () => null, disabled = false, chevron = false, } = props;
+    const { options, onClick = () => null, onClose = () => null, disabled = false, arrow = false, } = props;
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
     const disabledStyles = {
@@ -41,7 +41,7 @@ export const IconsMenu = props => {
                                             bgcolor: option.disabled ? 'grey.300' : 'grey.200',
                                             width: 24,
                                             height: 24,
-                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), chevron && (_jsx(ListItemIcon, { sx: {
+                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
                                         minWidth: 'auto',
                                         marginLeft: 'auto',
                                         color: option.disabled ? 'text.disabled' : 'inherit',

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -48,7 +48,7 @@ export const IconsMenu = props => {
                                             color: 'grey.700',
                                             width: 24,
                                             height: 24,
-                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { mr: 1, color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
+                                        }, children: option.icon }) })), _jsx(ListItemText, { sx: Object.assign(Object.assign({}, option.textProps), { mr: 3, color: option.disabled ? 'text.disabled' : option.color }), children: option.label }), arrow && (_jsx(ListItemIcon, { sx: {
                                         color: option.disabled ? 'text.disabled' : 'inherit',
                                         minWidth: 0,
                                         marginRight: 0,

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -19,7 +19,6 @@ export type Option = {
   textProps?: SxProps;
   color?: string;
   disabled?: boolean;
-  arrow?: boolean;
 };
 
 export type IconsMenuProps = {
@@ -101,18 +100,26 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
             <MenuItem
               onClick={handleOptionClick(option.onClick)}
               disabled={option.disabled}
+              sx={{
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                display: 'flex',
+                pr: 0,
+              }}
             >
               {option.icon && (
                 <ListItemIcon
                   sx={{
                     '&>*': {
                       color: option.disabled ? 'text.disabled' : option.color,
+                      minWidth: 0,
                     },
                   }}
                 >
                   <Avatar
                     sx={{
                       bgcolor: option.disabled ? 'grey.300' : 'grey.200',
+                      color: 'grey.700',
                       width: 24,
                       height: 24,
                     }}
@@ -132,9 +139,9 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
               {arrow && (
                 <ListItemIcon
                   sx={{
-                    minWidth: 'auto',
-                    marginLeft: 'auto',
                     color: option.disabled ? 'text.disabled' : 'inherit',
+                    minWidth: 0,
+                    mr: 0,
                   }}
                 >
                   <ChevronRight />

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -107,7 +107,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                 pr: 0,
               }}
             >
-              {option.icon && (
+              {false && option.icon && (
                 <ListItemIcon
                   sx={{
                     '&>*': {
@@ -119,7 +119,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                   <Avatar
                     sx={{
                       bgcolor: option.disabled ? 'grey.300' : 'grey.200',
-                      color: 'grey.700',
+                      color: 'black',
                       width: 24,
                       height: 24,
                     }}
@@ -141,7 +141,8 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                   sx={{
                     color: option.disabled ? 'text.disabled' : 'inherit',
                     minWidth: 0,
-                    mr: 0,
+                    marginRight: 0,
+                    marginLeft: 0,
                   }}
                 >
                   <ChevronRight />

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -118,7 +118,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                 >
                   <Avatar
                     sx={{
-                      bgcolor: option.disabled ? 'grey.300' : 'grey.200',
+                      bgcolor: option.disabled ? 'grey.200' : 'grey.100',
                       color: 'grey.700',
                       width: 24,
                       height: 24,

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -27,7 +27,7 @@ export type IconsMenuProps = {
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onClose?: (event: MouseEvent) => void;
   disabled?: boolean;
-  chevron?: boolean;
+  arrow?: boolean;
 };
 
 export const IconsMenu: FC<IconsMenuProps> = props => {
@@ -36,7 +36,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
     onClick = () => null,
     onClose = () => null,
     disabled = false,
-    chevron = false,
+    arrow = false,
   } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -129,7 +129,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
               >
                 {option.label}
               </ListItemText>
-              {chevron && (
+              {arrow && (
                 <ListItemIcon
                   sx={{
                     minWidth: 'auto',

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -1,5 +1,6 @@
 import { FC, MouseEvent, useState } from 'react';
 import {
+  Avatar,
   Divider,
   IconButton,
   ListItemIcon,
@@ -8,7 +9,7 @@ import {
   MenuItem,
   SxProps,
 } from '@mui/material';
-import { MoreVert as MoreVertIcon } from '@mui/icons-material';
+import { ChevronRight, MoreVert as MoreVertIcon } from '@mui/icons-material';
 
 export type Option = {
   onClick: () => void;
@@ -18,6 +19,7 @@ export type Option = {
   textProps?: SxProps;
   color?: string;
   disabled?: boolean;
+  arrow?: boolean;
 };
 
 export type IconsMenuProps = {
@@ -25,6 +27,7 @@ export type IconsMenuProps = {
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onClose?: (event: MouseEvent) => void;
   disabled?: boolean;
+  chevron?: boolean;
 };
 
 export const IconsMenu: FC<IconsMenuProps> = props => {
@@ -33,6 +36,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
     onClick = () => null,
     onClose = () => null,
     disabled = false,
+    chevron = false,
   } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -106,7 +110,15 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                     },
                   }}
                 >
-                  {option.icon}
+                  <Avatar
+                    sx={{
+                      bgcolor: option.disabled ? 'grey.300' : 'grey.200',
+                      width: 24,
+                      height: 24,
+                    }}
+                  >
+                    {option.icon}
+                  </Avatar>
                 </ListItemIcon>
               )}
               <ListItemText
@@ -117,8 +129,19 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
               >
                 {option.label}
               </ListItemText>
+              {chevron && (
+                <ListItemIcon
+                  sx={{
+                    minWidth: 'auto',
+                    marginLeft: 'auto',
+                    color: option.disabled ? 'text.disabled' : 'inherit',
+                  }}
+                >
+                  <ChevronRight />
+                </ListItemIcon>
+              )}
             </MenuItem>
-            {option.divider && <Divider />}
+            {option.divider && <Divider sx={{ px: 1 }} />}
           </div>
         ))}
       </Menu>

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -107,7 +107,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                 pr: 0,
               }}
             >
-              {false && option.icon && (
+              {option.icon && (
                 <ListItemIcon
                   sx={{
                     '&>*': {
@@ -134,7 +134,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                   color: option.disabled ? 'text.disabled' : option.color,
                 }}
               >
-                {option.label} test
+                {option.label}
               </ListItemText>
               {arrow && (
                 <ListItemIcon
@@ -143,6 +143,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                     minWidth: 0,
                     marginRight: 0,
                     marginLeft: 0,
+                    fontWeight: 600,
                   }}
                 >
                   <ChevronRight />

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -9,7 +9,10 @@ import {
   MenuItem,
   SxProps,
 } from '@mui/material';
-import { ChevronRight, MoreVert as MoreVertIcon } from '@mui/icons-material';
+import {
+  ChevronRight as ChevronRightIcon,
+  MoreVert as MoreVertIcon,
+} from '@mui/icons-material';
 
 export type Option = {
   onClick: () => void;
@@ -147,7 +150,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                     fontWeight: 600,
                   }}
                 >
-                  <ChevronRight />
+                  <ChevronRightIcon />
                 </ListItemIcon>
               )}
             </MenuItem>

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -131,7 +131,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
               <ListItemText
                 sx={{
                   ...option.textProps,
-                  mr: 1,
+                  mr: 3,
                   color: option.disabled ? 'text.disabled' : option.color,
                 }}
               >

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -134,7 +134,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                   color: option.disabled ? 'text.disabled' : option.color,
                 }}
               >
-                {option.label}
+                {option.label} test
               </ListItemText>
               {arrow && (
                 <ListItemIcon
@@ -148,7 +148,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                 </ListItemIcon>
               )}
             </MenuItem>
-            {option.divider && <Divider sx={{ px: 1 }} />}
+            {option.divider && <Divider sx={{ mx: 1 }} />}
           </div>
         ))}
       </Menu>

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -119,7 +119,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
                   <Avatar
                     sx={{
                       bgcolor: option.disabled ? 'grey.300' : 'grey.200',
-                      color: 'black',
+                      color: 'grey.700',
                       width: 24,
                       height: 24,
                     }}
@@ -131,6 +131,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
               <ListItemText
                 sx={{
                   ...option.textProps,
+                  mr: 1,
                   color: option.disabled ? 'text.disabled' : option.color,
                 }}
               >


### PR DESCRIPTION
## Summary
Se busca lograr una nueva version del IconsMenu. Icono como avatar con fondo gris, con una arrow opcional como veremos en la imagen

`Sin arrow ni divider (default):`

<img width="220" alt="Screenshot 2024-06-26 at 3 26 35 PM" src="https://github.com/HumandDev/material-hu/assets/95429033/abeb671e-5da1-43ff-ae7b-a9d2c229c430">

`Con arrow y divider:`

<img width="220" alt="Screenshot 2024-06-26 at 3 29 30 PM" src="https://github.com/HumandDev/material-hu/assets/95429033/7df41144-2de6-4224-9055-d47e61c15521">
