### PR TITLE
Add Attachment Format Support

### DIFF
--- a/lib/components/FormDrop.d.ts
+++ b/lib/components/FormDrop.d.ts
@@ -7,8 +7,13 @@ export declare enum FormDropTypes {
     FILE = "file"
 }
 export type FormDropValue = {
-    url?: string | null;
     file?: File;
+    url?: string | null;
+    attachment?: {
+        id: number;
+        url?: string;
+        type?: string;
+    } | null;
 };
 export type FormDropContext = {
     maxSize: number;
@@ -39,6 +44,7 @@ export type FormDropProps = {
     saveLabel?: string;
     cropLabel?: string;
     sliderLabel?: string;
+    attachmentFormatEnabled?: boolean;
 };
 export declare const FormDrop: FC<FormDropProps>;
 export default FormDrop;

--- a/lib/components/FormDrop.js
+++ b/lib/components/FormDrop.js
@@ -32,14 +32,14 @@ const RECOMMENDED_WIDTH = 900;
 const RECOMMENDED_HEIGHT = 400;
 export const FormDrop = props => {
     var _a, _b;
-    const { name, rules, maxSize: maxSizeProp, recommendedWidth = RECOMMENDED_WIDTH, recommendedHeight = RECOMMENDED_HEIGHT, getErrorMessage = () => '', altLabel = () => '', deleteLabel = () => '', helpTextLabel = () => '', linkLabel = () => '', sizeLabel = () => '', openLabel = () => '', label = () => '', accept: acceptProp, type = FormDropTypes.IMAGE, onDrop = () => null, withCrop, cancelLabel, saveLabel, cropLabel, sliderLabel, } = props;
+    const { name, rules, maxSize: maxSizeProp, recommendedWidth = RECOMMENDED_WIDTH, recommendedHeight = RECOMMENDED_HEIGHT, getErrorMessage = () => '', altLabel = () => '', deleteLabel = () => '', helpTextLabel = () => '', linkLabel = () => '', sizeLabel = () => '', openLabel = () => '', label = () => '', accept: acceptProp, type = FormDropTypes.IMAGE, onDrop = () => null, withCrop, cancelLabel, saveLabel, cropLabel, sliderLabel, attachmentFormatEnabled = false, } = props;
     const theme = useTheme();
     const accept = acceptProp || ACCEPT_BY_TYPE[type];
     const maxSize = maxSizeProp || MAX_SIZE_BY_TYPE[type];
     const { control, trigger, setError, getFieldState } = useFormContext();
     const errorMessage = (_b = (_a = getFieldState(name)) === null || _a === void 0 ? void 0 : _a.error) === null || _b === void 0 ? void 0 : _b.message;
     return (_jsx(Controller, { name: name, control: control, rules: rules, render: ({ field: { onChange, value } }) => {
-            var _a, _b;
+            var _a;
             const dropValue = value;
             const context = {
                 maxSize,
@@ -49,7 +49,7 @@ export const FormDrop = props => {
                 value,
             };
             const handleSaveCropping = (file) => {
-                onChange({ file, url: null });
+                onChange({ file, url: null, attachment: null });
                 trigger(name);
             };
             const { modal: croppingModal, showModal: showCroppingModal } = useModal(CroppingModal, {
@@ -71,8 +71,8 @@ export const FormDrop = props => {
                     showCroppingModal({ file: files[0] });
                     return;
                 }
-                onDrop({ file: files[0], url: null });
-                onChange({ file: files[0], url: null });
+                onDrop({ file: files[0], url: null, attachment: null });
+                onChange({ file: files[0], url: null, attachment: null });
                 trigger(name);
             };
             const handleDelete = () => {
@@ -96,14 +96,27 @@ export const FormDrop = props => {
                 multiple: false,
                 maxSize,
             });
-            const hasValue = (((_a = dropValue === null || dropValue === void 0 ? void 0 : dropValue.url) === null || _a === void 0 ? void 0 : _a.length) && dropValue.url.length > 0) ||
-                !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.file);
+            const hasValue = useMemo(() => attachmentFormatEnabled
+                ? !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.file) ||
+                    (!!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.attachment) && !!dropValue.attachment.url)
+                : !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.file) || !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.url), [
+                attachmentFormatEnabled,
+                dropValue === null || dropValue === void 0 ? void 0 : dropValue.attachment,
+                dropValue === null || dropValue === void 0 ? void 0 : dropValue.file,
+                dropValue === null || dropValue === void 0 ? void 0 : dropValue.url,
+            ]);
             const src = useMemo(() => {
                 if (!dropValue)
                     return undefined;
-                const { url, file } = dropValue;
-                return url || (file && URL.createObjectURL(file));
-            }, [hasValue]);
+                if (attachmentFormatEnabled) {
+                    const { attachment, file } = dropValue;
+                    return (attachment === null || attachment === void 0 ? void 0 : attachment.url) || (file && URL.createObjectURL(file));
+                }
+                else {
+                    const { url, file } = dropValue;
+                    return url || (file && URL.createObjectURL(file));
+                }
+            }, [hasValue, attachmentFormatEnabled]);
             return (_jsxs(Stack, { spacing: 3, width: "100%", children: [type === FormDropTypes.IMAGE && withCrop && croppingModal, hasValue && !DOCUMENT_TYPES.includes(type) && (_jsxs(_Fragment, { children: [_jsx(Box, { component: type === FormDropTypes.IMAGE ? 'img' : 'video', src: src, alt: altLabel(context), controls: true, sx: {
                                     width: '100%',
                                     height: 'auto',
@@ -113,7 +126,7 @@ export const FormDrop = props => {
                                     borderRadius: '20px',
                                 } }), _jsx(Button, { onClick: handleDelete, sx: { width: 'fit-content' }, children: deleteLabel(context) })] })), hasValue && DOCUMENT_TYPES.includes(type) && (_jsx(Stack, { sx: {
                             gap: 1,
-                        }, children: _jsx(DocumentItem, { name: ((_b = value.file) === null || _b === void 0 ? void 0 : _b.name) || '', size: sizeLabel(context), url: src, openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete, type: type === FormDropTypes.PDF
+                        }, children: _jsx(DocumentItem, { name: ((_a = value.file) === null || _a === void 0 ? void 0 : _a.name) || '', size: sizeLabel(context), url: src, openLabel: openLabel(context), deleteLabel: deleteLabel(context), onDelete: handleDelete, type: type === FormDropTypes.PDF
                                 ? DocumentItemTypes.PDF
                                 : DocumentItemTypes.FILE }) })), !hasValue && (_jsxs(_Fragment, { children: [_jsxs(Box, Object.assign({ "aria-describedby": "drop-picture-error-text", sx: {
                                     borderWidth: '1px',

--- a/lib/components/FormDrop.js
+++ b/lib/components/FormDrop.js
@@ -96,15 +96,10 @@ export const FormDrop = props => {
                 multiple: false,
                 maxSize,
             });
-            const hasValue = useMemo(() => attachmentFormatEnabled
+            const hasValue = attachmentFormatEnabled
                 ? !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.file) ||
                     (!!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.attachment) && !!dropValue.attachment.url)
-                : !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.file) || !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.url), [
-                attachmentFormatEnabled,
-                dropValue === null || dropValue === void 0 ? void 0 : dropValue.attachment,
-                dropValue === null || dropValue === void 0 ? void 0 : dropValue.file,
-                dropValue === null || dropValue === void 0 ? void 0 : dropValue.url,
-            ]);
+                : !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.file) || !!(dropValue === null || dropValue === void 0 ? void 0 : dropValue.url);
             const src = useMemo(() => {
                 if (!dropValue)
                     return undefined;

--- a/src/components/FormDrop.tsx
+++ b/src/components/FormDrop.tsx
@@ -44,8 +44,13 @@ const RECOMMENDED_WIDTH = 900;
 const RECOMMENDED_HEIGHT = 400;
 
 export type FormDropValue = {
-  url?: string | null;
   file?: File;
+  url?: string | null;
+  attachment?: {
+    id: number;
+    url?: string;
+    type?: string;
+  } | null;
 };
 
 export type FormDropContext = {
@@ -78,6 +83,7 @@ export type FormDropProps = {
   saveLabel?: string;
   cropLabel?: string;
   sliderLabel?: string;
+  attachmentFormatEnabled?: boolean;
 };
 
 export const FormDrop: FC<FormDropProps> = props => {
@@ -103,6 +109,7 @@ export const FormDrop: FC<FormDropProps> = props => {
     saveLabel,
     cropLabel,
     sliderLabel,
+    attachmentFormatEnabled = false,
   } = props;
 
   const theme = useTheme();
@@ -131,7 +138,7 @@ export const FormDrop: FC<FormDropProps> = props => {
         };
 
         const handleSaveCropping = (file: File) => {
-          onChange({ file, url: null });
+          onChange({ file, url: null, attachment: null });
           trigger(name);
         };
 
@@ -161,8 +168,8 @@ export const FormDrop: FC<FormDropProps> = props => {
             return;
           }
 
-          onDrop({ file: files[0], url: null });
-          onChange({ file: files[0], url: null });
+          onDrop({ file: files[0], url: null, attachment: null });
+          onChange({ file: files[0], url: null, attachment: null });
           trigger(name);
         };
 
@@ -193,17 +200,31 @@ export const FormDrop: FC<FormDropProps> = props => {
           maxSize,
         });
 
-        const hasValue =
-          (dropValue?.url?.length && dropValue.url.length > 0) ||
-          !!dropValue?.file;
+        const hasValue = useMemo(
+          () =>
+            attachmentFormatEnabled
+              ? !!dropValue?.file ||
+                (!!dropValue?.attachment && !!dropValue.attachment.url)
+              : !!dropValue?.file || !!dropValue?.url,
+          [
+            attachmentFormatEnabled,
+            dropValue?.attachment,
+            dropValue?.file,
+            dropValue?.url,
+          ],
+        );
 
         const src = useMemo(() => {
           if (!dropValue) return undefined;
 
-          const { url, file } = dropValue;
-
-          return url || (file && URL.createObjectURL(file));
-        }, [hasValue]);
+          if (attachmentFormatEnabled) {
+            const { attachment, file } = dropValue;
+            return attachment?.url || (file && URL.createObjectURL(file));
+          } else {
+            const { url, file } = dropValue;
+            return url || (file && URL.createObjectURL(file));
+          }
+        }, [hasValue, attachmentFormatEnabled]);
 
         return (
           <Stack

--- a/src/components/FormDrop.tsx
+++ b/src/components/FormDrop.tsx
@@ -200,19 +200,10 @@ export const FormDrop: FC<FormDropProps> = props => {
           maxSize,
         });
 
-        const hasValue = useMemo(
-          () =>
-            attachmentFormatEnabled
-              ? !!dropValue?.file ||
-                (!!dropValue?.attachment && !!dropValue.attachment.url)
-              : !!dropValue?.file || !!dropValue?.url,
-          [
-            attachmentFormatEnabled,
-            dropValue?.attachment,
-            dropValue?.file,
-            dropValue?.url,
-          ],
-        );
+        const hasValue = attachmentFormatEnabled
+          ? !!dropValue?.file ||
+            (!!dropValue?.attachment && !!dropValue.attachment.url)
+          : !!dropValue?.file || !!dropValue?.url;
 
         const src = useMemo(() => {
           if (!dropValue) return undefined;


### PR DESCRIPTION
## Summary
Como se detalla [aca](https://www.notion.so/humand-co/Attachments-2-0-5095a62075524668b34cfc72d9127110), pasaremos a usar el servicio de attachments que disponibiliza la api para crear archivos. En este PR se modifica el componente `FormDrop` para que permita esta nueva funcionalidad de manera optativa - mediante la prop `attachmentFormatEnabled`
