### PR TITLE
Add iconButtonProps for IconsMenu

### DIFF
--- a/lib/components/IconsMenu.d.ts
+++ b/lib/components/IconsMenu.d.ts
@@ -1,5 +1,5 @@
 import { FC, MouseEvent } from 'react';
-import { SxProps } from '@mui/material';
+import { SxProps, IconButtonProps } from '@mui/material';
 export type Option = {
     onClick: () => void;
     label: string;
@@ -15,6 +15,7 @@ export type IconsMenuProps = {
     onClose?: (event: MouseEvent) => void;
     disabled?: boolean;
     arrow?: boolean;
+    iconButtonProps?: IconButtonProps;
 };
 export declare const IconsMenu: FC<IconsMenuProps>;
 export default IconsMenu;

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -1,9 +1,9 @@
 import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
 import { useState } from 'react';
-import { Avatar, Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
+import { Avatar, Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem } from '@mui/material';
 import { ChevronRight as ChevronRightIcon, MoreVert as MoreVertIcon, } from '@mui/icons-material';
 export const IconsMenu = props => {
-    const { options, onClick = () => null, onClose = () => null, disabled = false, arrow = false, } = props;
+    const { options, onClick = () => null, onClose = () => null, disabled = false, arrow = false, iconButtonProps = {}, } = props;
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
     const disabledStyles = {
@@ -25,7 +25,7 @@ export const IconsMenu = props => {
         handleClose(event);
         callback();
     };
-    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { "aria-label": "menu", "aria-controls": "icon-menu", "aria-haspopup": "true", "aria-expanded": open ? 'true' : undefined, id: "button-menu", onClick: disabled ? undefined : handleClick, disableRipple: disabled, children: _jsx(MoreVertIcon, { sx: disabled ? disabledStyles : undefined }) }), _jsx(Menu, { id: "icon-menu", anchorEl: anchorEl, open: open, onClose: handleClose, MenuListProps: {
+    return (_jsxs(_Fragment, { children: [_jsx(IconButton, Object.assign({ "aria-label": "menu", "aria-controls": "icon-menu", "aria-haspopup": "true", "aria-expanded": open ? 'true' : undefined, id: "button-menu", onClick: disabled ? undefined : handleClick, disableRipple: disabled }, iconButtonProps, { children: _jsx(MoreVertIcon, { sx: disabled ? disabledStyles : undefined }) })), _jsx(Menu, { id: "icon-menu", anchorEl: anchorEl, open: open, onClose: handleClose, MenuListProps: {
                     'aria-labelledby': 'button-menu',
                 }, anchorOrigin: {
                     vertical: 'bottom',

--- a/lib/components/IconsMenu.js
+++ b/lib/components/IconsMenu.js
@@ -1,6 +1,6 @@
 import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
 import { useState } from 'react';
-import { Avatar, Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem } from '@mui/material';
+import { Avatar, Divider, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, } from '@mui/material';
 import { ChevronRight as ChevronRightIcon, MoreVert as MoreVertIcon, } from '@mui/icons-material';
 export const IconsMenu = props => {
     const { options, onClick = () => null, onClose = () => null, disabled = false, arrow = false, iconButtonProps = {}, } = props;

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -31,7 +31,7 @@ export type IconsMenuProps = {
   onClose?: (event: MouseEvent) => void;
   disabled?: boolean;
   arrow?: boolean;
-  iconButtonProps?: IconButtonProps; 
+  iconButtonProps?: IconButtonProps;
 };
 
 export const IconsMenu: FC<IconsMenuProps> = props => {

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -8,7 +8,7 @@ import {
   Menu,
   MenuItem,
   SxProps,
-  IconButtonProps
+  IconButtonProps,
 } from '@mui/material';
 import {
   ChevronRight as ChevronRightIcon,

--- a/src/components/IconsMenu.tsx
+++ b/src/components/IconsMenu.tsx
@@ -8,6 +8,7 @@ import {
   Menu,
   MenuItem,
   SxProps,
+  IconButtonProps
 } from '@mui/material';
 import {
   ChevronRight as ChevronRightIcon,
@@ -30,6 +31,7 @@ export type IconsMenuProps = {
   onClose?: (event: MouseEvent) => void;
   disabled?: boolean;
   arrow?: boolean;
+  iconButtonProps?: IconButtonProps; 
 };
 
 export const IconsMenu: FC<IconsMenuProps> = props => {
@@ -39,6 +41,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
     onClose = () => null,
     disabled = false,
     arrow = false,
+    iconButtonProps = {},
   } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -78,6 +81,7 @@ export const IconsMenu: FC<IconsMenuProps> = props => {
         id="button-menu"
         onClick={disabled ? undefined : handleClick}
         disableRipple={disabled}
+        {...iconButtonProps}
       >
         <MoreVertIcon sx={disabled ? disabledStyles : undefined} />
       </IconButton>


### PR DESCRIPTION
## Summary
Se suma la prop iconButtonProps al IconsMenu para poder pasarle `sx` u otras props importantes