### PR TITLE
[SQDP-884] Agregar componentes a HorizontalStepper

### DIFF
--- a/lib/components/HorizontalStepper.d.ts
+++ b/lib/components/HorizontalStepper.d.ts
@@ -21,6 +21,8 @@ export type HorizontalStepperProps = StepperProps & {
     onClose?: () => void;
     closeLabel?: string;
     title?: string;
+    titleRightComponent?: ReactNode;
+    actions?: ReactNode;
     backButton?: {
         onClick?: () => void;
         getLabel?: (step: StepType) => string | null;

--- a/lib/components/HorizontalStepper.js
+++ b/lib/components/HorizontalStepper.js
@@ -14,11 +14,11 @@ import { Stepper, Step, StepLabel, StepButton, Divider, Button, Stack, Box, Typo
 import { Check, Close } from '@mui/icons-material';
 export const HorizontalStepper = props => {
     var _a, _b;
-    const { steps, activeStep = 0, disabled = false, clickable = false, nonLinear = false, onSelectStep = () => null, onClose, closeLabel, title, finishButton, backButton, nextButton, stateLabels = {
+    const { steps, activeStep = 0, disabled = false, clickable = false, nonLinear = false, onSelectStep = () => null, onClose, closeLabel, title, titleRightComponent, actions, finishButton, backButton, nextButton, stateLabels = {
         active: '',
         completed: '',
         pending: '',
-    } } = props, stepperProps = __rest(props, ["steps", "activeStep", "disabled", "clickable", "nonLinear", "onSelectStep", "onClose", "closeLabel", "title", "finishButton", "backButton", "nextButton", "stateLabels"]);
+    } } = props, stepperProps = __rest(props, ["steps", "activeStep", "disabled", "clickable", "nonLinear", "onSelectStep", "onClose", "closeLabel", "title", "titleRightComponent", "actions", "finishButton", "backButton", "nextButton", "stateLabels"]);
     const theme = useTheme();
     const validStep = (step) => step >= 0 && step < steps.length;
     const getStepState = (step, completed) => {
@@ -53,7 +53,7 @@ export const HorizontalStepper = props => {
                     py: 2,
                     px: 3,
                     width: '100%',
-                }, children: [(title || onClose) && (_jsxs(Stack, { sx: {
+                }, children: [(title || titleRightComponent || onClose) && (_jsxs(Stack, { sx: {
                             flexDirection: 'row',
                             alignItems: 'center',
                             justifyContent: 'flex-start',
@@ -61,12 +61,14 @@ export const HorizontalStepper = props => {
                             position: 'absolute',
                             left: theme.spacing(3),
                         }, children: [onClose && (_jsx(Tooltip, { title: closeLabel, children: _jsx(IconButton, { onClick: onClose, "aria-label": closeLabel, children: _jsx(Close, { fontSize: "small" }) }) })), title && (_jsx(Typography, { variant: "h5", sx: {
-                                    [theme.breakpoints.down('lg')]: {
+                                    [theme.breakpoints.down('xl')]: {
                                         display: 'none',
                                     },
-                                }, children: title }))] })), _jsx(Stack, Object.assign({ component: Stepper, activeStep: activeStep, connector: null, nonLinear: nonLinear, sx: Object.assign({ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: 5, [theme.breakpoints.up('lg')]: {
-                                gap: 7,
-                            } }, stepperProps === null || stepperProps === void 0 ? void 0 : stepperProps.sx) }, stepperProps, { children: steps.map((step, index) => {
+                                }, children: title })), _jsx(Stack, { sx: {
+                                    [theme.breakpoints.down('xl')]: {
+                                        display: 'none',
+                                    },
+                                }, children: titleRightComponent })] })), _jsx(Stack, Object.assign({ component: Stepper, activeStep: activeStep, connector: null, nonLinear: nonLinear, sx: Object.assign({ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: 7 }, stepperProps === null || stepperProps === void 0 ? void 0 : stepperProps.sx) }, stepperProps, { children: steps.map((step, index) => {
                             const { id, label, completed, disabled: stepDisabled, stepProps = {}, stepLabelProps = {}, stepButtonProps = {}, } = step;
                             const labelComponent = (_jsxs(_Fragment, { children: [_jsx(Typography, { className: "state", variant: "caption", component: "span", children: getStepState(index, completed) }), _jsx(Typography, { className: "label", variant: "subtitle2", component: "span", children: label })] }));
                             return (_jsxs(Step, Object.assign({ completed: index !== activeStep && completed }, stepProps, { sx: {
@@ -117,7 +119,19 @@ export const HorizontalStepper = props => {
                                             },
                                         },
                                     },
+                                    [theme.breakpoints.down('lg')]: {
+                                        '& .MuiStepIcon-root': {
+                                            display: 'none',
+                                        },
+                                    },
                                 }, children: [clickable && (_jsx(StepButton, Object.assign({ icon: getStepIcon(index, completed), disabled: disabled || stepDisabled, onClick: handleSelectStep(index) }, stepButtonProps, { children: labelComponent }))), !clickable && (_jsx(StepLabel, Object.assign({ icon: getStepIcon(index, completed) }, stepLabelProps, { children: labelComponent })))] }), id));
-                        }) }))] }), _jsx(Divider, {}), !!currentStep && currentStep.content({ activeStep, id: currentStep.id }), _jsxs(Stack, { component: Container, maxWidth: "md", flexDirection: "row", py: 2, sx: { backgroundColor: 'background.default' }, children: [!!prevStep && !!backButton && (_jsx(Button, { id: "horizontal-stepper-back-button", onClick: backButton.onClick, disabled: disabled || backButton.disabled, children: (_a = backButton.getLabel) === null || _a === void 0 ? void 0 : _a.call(backButton, prevStep) })), !!nextStep && !!nextButton && (_jsx(Button, { id: "horizontal-stepper-next-button", variant: "contained", onClick: nextButton.onClick, disabled: disabled || nextButton.disabled, sx: { ml: 'auto' }, children: (_b = nextButton.getLabel) === null || _b === void 0 ? void 0 : _b.call(nextButton, nextStep) })), !nextStep && !!finishButton && (_jsx(Button, { id: "horizontal-stepper-finish-button", variant: "contained", onClick: finishButton.onClick, disabled: disabled || finishButton.disabled, sx: { ml: 'auto' }, children: finishButton.label }))] })] }));
+                        }) })), actions && (_jsx(Stack, { sx: {
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            justifyContent: 'flex-end',
+                            gap: 2,
+                            position: 'absolute',
+                            right: theme.spacing(3),
+                        }, children: actions }))] }), _jsx(Divider, {}), !!currentStep && currentStep.content({ activeStep, id: currentStep.id }), _jsxs(Stack, { component: Container, maxWidth: "md", flexDirection: "row", py: 2, sx: { backgroundColor: 'background.default' }, children: [!!prevStep && !!backButton && (_jsx(Button, { id: "horizontal-stepper-back-button", onClick: backButton.onClick, disabled: disabled || backButton.disabled, children: (_a = backButton.getLabel) === null || _a === void 0 ? void 0 : _a.call(backButton, prevStep) })), !!nextStep && !!nextButton && (_jsx(Button, { id: "horizontal-stepper-next-button", variant: "contained", onClick: nextButton.onClick, disabled: disabled || nextButton.disabled, sx: { ml: 'auto' }, children: (_b = nextButton.getLabel) === null || _b === void 0 ? void 0 : _b.call(nextButton, nextStep) })), !nextStep && !!finishButton && (_jsx(Button, { id: "horizontal-stepper-finish-button", variant: "contained", onClick: finishButton.onClick, disabled: disabled || finishButton.disabled, sx: { ml: 'auto' }, children: finishButton.label }))] })] }));
 };
 export default HorizontalStepper;

--- a/src/components/HorizontalStepper.tsx
+++ b/src/components/HorizontalStepper.tsx
@@ -40,6 +40,8 @@ export type HorizontalStepperProps = StepperProps & {
   onClose?: () => void;
   closeLabel?: string;
   title?: string;
+  titleRightComponent?: ReactNode;
+  actions?: ReactNode;
   backButton?: {
     onClick?: () => void;
     getLabel?: (step: StepType) => string | null;
@@ -73,6 +75,8 @@ export const HorizontalStepper: FC<HorizontalStepperProps> = props => {
     onClose,
     closeLabel,
     title,
+    titleRightComponent,
+    actions,
     finishButton,
     backButton,
     nextButton,
@@ -131,7 +135,7 @@ export const HorizontalStepper: FC<HorizontalStepperProps> = props => {
           width: '100%',
         }}
       >
-        {(title || onClose) && (
+        {(title || titleRightComponent || onClose) && (
           <Stack
             sx={{
               flexDirection: 'row',
@@ -156,7 +160,7 @@ export const HorizontalStepper: FC<HorizontalStepperProps> = props => {
               <Typography
                 variant="h5"
                 sx={{
-                  [theme.breakpoints.down('lg')]: {
+                  [theme.breakpoints.down('xl')]: {
                     display: 'none',
                   },
                 }}
@@ -164,6 +168,15 @@ export const HorizontalStepper: FC<HorizontalStepperProps> = props => {
                 {title}
               </Typography>
             )}
+            <Stack
+              sx={{
+                [theme.breakpoints.down('xl')]: {
+                  display: 'none',
+                },
+              }}
+            >
+              {titleRightComponent}
+            </Stack>
           </Stack>
         )}
         <Stack
@@ -175,10 +188,7 @@ export const HorizontalStepper: FC<HorizontalStepperProps> = props => {
             flexDirection: 'row',
             justifyContent: 'center',
             alignItems: 'center',
-            gap: 5,
-            [theme.breakpoints.up('lg')]: {
-              gap: 7,
-            },
+            gap: 7,
             ...stepperProps?.sx,
           }}
           {...stepperProps}
@@ -266,6 +276,11 @@ export const HorizontalStepper: FC<HorizontalStepperProps> = props => {
                       },
                     },
                   },
+                  [theme.breakpoints.down('lg')]: {
+                    '& .MuiStepIcon-root': {
+                      display: 'none',
+                    },
+                  },
                 }}
               >
                 {clickable && (
@@ -290,6 +305,20 @@ export const HorizontalStepper: FC<HorizontalStepperProps> = props => {
             );
           })}
         </Stack>
+        {actions && (
+          <Stack
+            sx={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              gap: 2,
+              position: 'absolute',
+              right: theme.spacing(3),
+            }}
+          >
+            {actions}
+          </Stack>
+        )}
       </Stack>
       <Divider />
       {!!currentStep && currentStep.content({ activeStep, id: currentStep.id })}


### PR DESCRIPTION
## Summary
- Se agregan los siguientes componentes que se reciben por props para configurar `HorizontalStepper`:
  - `titleLeftComponent`.
  - `actions`.

## Jira Card
[Trainings | Guardar como borrador](https://humand.atlassian.net/browse/SQDP-884)