### PR TITLE
Added tooltip component

### DIFF
--- a/lib/components/Title/Title.d.ts
+++ b/lib/components/Title/Title.d.ts
@@ -2,11 +2,13 @@ import { StackProps } from '@mui/material';
 type TitleVariant = 'XL' | 'L' | 'M' | 'S';
 type Props = {
     copetin?: string;
+    copetinTooltip?: string;
     description?: string;
+    descriptionTooltip?: string;
     title: string;
     centered?: boolean;
     variant: TitleVariant;
     sx?: StackProps['sx'];
 };
-declare const Title: ({ centered, copetin, description, title, variant, sx, }: Props) => import("react/jsx-runtime").JSX.Element;
+declare const Title: ({ centered, copetin, copetinTooltip, description, descriptionTooltip, title, variant, sx, }: Props) => import("react/jsx-runtime").JSX.Element;
 export default Title;

--- a/lib/components/Title/Title.js
+++ b/lib/components/Title/Title.js
@@ -1,6 +1,26 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Stack, Typography } from '@mui/material';
+import Tooltip from '../Tooltip/Tooltip';
 import { colorPalette } from '../../theme/hugo/colors';
+import { IconInfoCircle, } from '@tabler/icons-react';
+const tooltipSize = {
+    XL: {
+        copetin: 16,
+        description: 18
+    },
+    L: {
+        copetin: 14,
+        description: 16
+    },
+    M: {
+        copetin: 12,
+        description: 14
+    },
+    S: {
+        copetin: 12,
+        description: 14
+    },
+};
 const adjustedCopetin = {
     XL: 'globalS',
     L: 'globalXS',
@@ -13,13 +33,19 @@ const adjustedDescription = {
     M: 'globalXS',
     S: 'globalXS',
 };
-const Title = ({ centered = false, copetin = '', description = '', title, variant, sx = {}, }) => {
-    return (_jsxs(Stack, { sx: Object.assign({ textAlign: centered ? 'center' : 'left' }, sx), children: [copetin && (_jsx(Typography, { variant: adjustedCopetin[variant], sx: {
+const Title = ({ centered = false, copetin = '', copetinTooltip = '', description = '', descriptionTooltip = '', title, variant, sx = {}, }) => {
+    return (_jsxs(Stack, { sx: Object.assign({ textAlign: centered ? 'center' : 'left' }, sx), children: [copetin && (_jsxs(Typography, { variant: adjustedCopetin[variant], sx: {
                     color: colorPalette.textColors.neutralTextLighter,
-                }, children: copetin })), _jsx(Typography, { variant: `global${variant}`, sx: {
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                }, children: [copetin, copetinTooltip && (_jsx(Tooltip, { direction: "top", title: copetinTooltip, children: _jsx(IconInfoCircle, { size: tooltipSize[variant].copetin, color: colorPalette.textColors.neutralTextLighter }) }))] })), _jsx(Typography, { variant: `global${variant}`, sx: {
                     color: colorPalette.textColors.neutralText,
-                }, fontWeight: 'fontWeightSemiBold', children: title }), description && (_jsx(Typography, { variant: adjustedDescription[variant], sx: {
+                }, fontWeight: 'fontWeightSemiBold', children: title }), description && (_jsxs(Typography, { variant: adjustedDescription[variant], sx: {
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
                     color: colorPalette.textColors.neutralTextLighter,
-                }, children: description }))] }));
+                }, children: [description, descriptionTooltip && (_jsx(Tooltip, { direction: "bottom", title: descriptionTooltip, children: _jsx(IconInfoCircle, { size: tooltipSize[variant].description, color: colorPalette.textColors.neutralTextLighter }) }))] }))] }));
 };
 export default Title;

--- a/lib/components/Title/Title.js
+++ b/lib/components/Title/Title.js
@@ -2,23 +2,23 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Stack, Typography } from '@mui/material';
 import Tooltip from '../Tooltip/Tooltip';
 import { colorPalette } from '../../theme/hugo/colors';
-import { IconInfoCircle, } from '@tabler/icons-react';
+import { IconInfoCircle } from '@tabler/icons-react';
 const tooltipSize = {
     XL: {
         copetin: 16,
-        description: 18
+        description: 18,
     },
     L: {
         copetin: 14,
-        description: 16
+        description: 16,
     },
     M: {
         copetin: 12,
-        description: 14
+        description: 14,
     },
     S: {
         copetin: 12,
-        description: 14
+        description: 14,
     },
 };
 const adjustedCopetin = {
@@ -38,14 +38,14 @@ const Title = ({ centered = false, copetin = '', copetinTooltip = '', descriptio
                     color: colorPalette.textColors.neutralTextLighter,
                     display: 'flex',
                     alignItems: 'center',
-                    gap: 1,
-                }, children: [copetin, copetinTooltip && (_jsx(Tooltip, { direction: "top", title: copetinTooltip, children: _jsx(IconInfoCircle, { size: tooltipSize[variant].copetin, color: colorPalette.textColors.neutralTextLighter }) }))] })), _jsx(Typography, { variant: `global${variant}`, sx: {
+                    gap: 0.5,
+                }, children: [copetin, copetinTooltip && (_jsx(Tooltip, { direction: "top", description: copetinTooltip, children: _jsx(IconInfoCircle, { size: tooltipSize[variant].copetin, color: colorPalette.textColors.neutralTextLighter }) }))] })), _jsx(Typography, { variant: `global${variant}`, sx: {
                     color: colorPalette.textColors.neutralText,
                 }, fontWeight: 'fontWeightSemiBold', children: title }), description && (_jsxs(Typography, { variant: adjustedDescription[variant], sx: {
                     display: 'flex',
                     alignItems: 'center',
-                    gap: 1,
+                    gap: 0.5,
                     color: colorPalette.textColors.neutralTextLighter,
-                }, children: [description, descriptionTooltip && (_jsx(Tooltip, { direction: "bottom", title: descriptionTooltip, children: _jsx(IconInfoCircle, { size: tooltipSize[variant].description, color: colorPalette.textColors.neutralTextLighter }) }))] }))] }));
+                }, children: [description, descriptionTooltip && (_jsx(Tooltip, { direction: "bottom", description: descriptionTooltip, children: _jsx(IconInfoCircle, { size: tooltipSize[variant].description, color: colorPalette.textColors.neutralTextLighter }) }))] }))] }));
 };
 export default Title;

--- a/lib/components/Tooltip/Tooltip.d.ts
+++ b/lib/components/Tooltip/Tooltip.d.ts
@@ -1,0 +1,11 @@
+import { FC, PropsWithChildren } from 'react';
+type TooltipBodyProps = {
+    title?: string;
+    description?: string;
+    isRemovable?: boolean;
+};
+export type TooltipProps = TooltipBodyProps & {
+    direction?: 'top' | 'left' | 'right' | 'bottom';
+};
+declare const Tooltip: FC<PropsWithChildren<TooltipProps>>;
+export default Tooltip;

--- a/lib/components/Tooltip/Tooltip.d.ts
+++ b/lib/components/Tooltip/Tooltip.d.ts
@@ -1,11 +1,10 @@
-import { FC, PropsWithChildren } from 'react';
 type TooltipBodyProps = {
     title?: string;
     description?: string;
-    isRemovable?: boolean;
 };
 export type TooltipProps = TooltipBodyProps & {
     direction?: 'top' | 'left' | 'right' | 'bottom';
+    children: any;
 };
-declare const Tooltip: FC<PropsWithChildren<TooltipProps>>;
+declare const Tooltip: ({ children, ...props }: TooltipProps) => import("react/jsx-runtime").JSX.Element;
 export default Tooltip;

--- a/lib/components/Tooltip/Tooltip.js
+++ b/lib/components/Tooltip/Tooltip.js
@@ -13,11 +13,11 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { colorPalette } from '../../theme/hugo/colors';
 import { Tooltip as MuiTooltip, Stack, Typography } from '@mui/material';
 const TooltipBody = ({ title, description }) => {
-    return (_jsx(Stack, { sx: { flexDirection: 'row', p: 1 }, children: _jsxs(Stack, { children: [_jsx(Typography, { variant: "globalS", sx: { fontWeight: 'semibold' }, children: title }), _jsx(Typography, { variant: "globalXS", children: description })] }) }));
+    return (_jsxs(Stack, { sx: { p: 1 }, children: [_jsx(Typography, { variant: "globalS", sx: { fontWeight: 'semibold' }, children: title }), _jsx(Typography, { variant: "globalXS", children: description })] }));
 };
 const Tooltip = (_a) => {
     var { children } = _a, props = __rest(_a, ["children"]);
-    const { title = '', description = '', direction = 'top', isRemovable = false, } = props;
+    const { title = '', description = '', direction = 'top' } = props;
     return (_jsx(MuiTooltip, { arrow: true, placement: direction, sx: {
             maxWidth: '312px',
             minWidth: '150px',
@@ -30,6 +30,6 @@ const Tooltip = (_a) => {
                     color: colorPalette.textColors.neutralText,
                 },
             },
-        }, title: _jsx(TooltipBody, { title: title, description: description, isRemovable: isRemovable }), children: children }));
+        }, title: _jsx(TooltipBody, { title: title, description: description }), children: children }));
 };
 export default Tooltip;

--- a/lib/components/Tooltip/Tooltip.js
+++ b/lib/components/Tooltip/Tooltip.js
@@ -1,0 +1,35 @@
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { colorPalette } from '../../theme/hugo/colors';
+import { Tooltip as MuiTooltip, Stack, Typography } from '@mui/material';
+const TooltipBody = ({ title, description }) => {
+    return (_jsx(Stack, { sx: { flexDirection: 'row', p: 1 }, children: _jsxs(Stack, { children: [_jsx(Typography, { variant: "globalS", sx: { fontWeight: 'semibold' }, children: title }), _jsx(Typography, { variant: "globalXS", children: description })] }) }));
+};
+const Tooltip = (_a) => {
+    var { children } = _a, props = __rest(_a, ["children"]);
+    const { title = '', description = '', direction = 'top', isRemovable = false, } = props;
+    return (_jsx(MuiTooltip, { arrow: true, placement: direction, sx: {
+            maxWidth: '312px',
+            minWidth: '150px',
+        }, PopperProps: {
+            sx: {
+                '.MuiTooltip-tooltip': {
+                    background: colorPalette.textColors.neutralText,
+                },
+                '.MuiTooltip-arrow': {
+                    color: colorPalette.textColors.neutralText,
+                },
+            },
+        }, title: _jsx(TooltipBody, { title: title, description: description, isRemovable: isRemovable }), children: children }));
+};
+export default Tooltip;

--- a/src/components/Title/Title.stories.tsx
+++ b/src/components/Title/Title.stories.tsx
@@ -17,5 +17,7 @@ export const Default: Story = {
     description: 'Description',
     title: 'Title',
     variant: 'XL',
+    descriptionTooltip: 'Description Tooltip',
+    copetinTooltip: 'Copetin Tooltip',
   },
 };

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -1,8 +1,29 @@
 import { Stack, StackProps, Typography } from '@mui/material';
+import Tooltip from '../Tooltip/Tooltip';
 import { colorPalette } from '../../theme/hugo/colors';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { TypographyPropsVariantOverrides } from '@mui/material/Typography/Typography';
 
 type TitleVariant = 'XL' | 'L' | 'M' | 'S';
+
+const tooltipSize = {
+  XL: {
+    copetin: 16,
+    description: 18,
+  },
+  L: {
+    copetin: 14,
+    description: 16,
+  },
+  M: {
+    copetin: 12,
+    description: 14,
+  },
+  S: {
+    copetin: 12,
+    description: 14,
+  },
+};
 
 const adjustedCopetin: Record<
   TitleVariant,
@@ -26,7 +47,9 @@ const adjustedDescription: Record<
 
 type Props = {
   copetin?: string;
+  copetinTooltip?: string;
   description?: string;
+  descriptionTooltip?: string;
   title: string;
   centered?: boolean;
   variant: TitleVariant;
@@ -36,7 +59,9 @@ type Props = {
 const Title = ({
   centered = false,
   copetin = '',
+  copetinTooltip = '',
   description = '',
+  descriptionTooltip = '',
   title,
   variant,
   sx = {},
@@ -53,9 +78,23 @@ const Title = ({
           variant={adjustedCopetin[variant]}
           sx={{
             color: colorPalette.textColors.neutralTextLighter,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
           }}
         >
           {copetin}
+          {copetinTooltip && (
+            <Tooltip
+              direction="top"
+              description={copetinTooltip}
+            >
+              <IconInfoCircle
+                size={tooltipSize[variant].copetin}
+                color={colorPalette.textColors.neutralTextLighter}
+              />
+            </Tooltip>
+          )}
         </Typography>
       )}
       <Typography
@@ -71,10 +110,24 @@ const Title = ({
         <Typography
           variant={adjustedDescription[variant]}
           sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
             color: colorPalette.textColors.neutralTextLighter,
           }}
         >
           {description}
+          {descriptionTooltip && (
+            <Tooltip
+              direction="bottom"
+              description={descriptionTooltip}
+            >
+              <IconInfoCircle
+                size={tooltipSize[variant].description}
+                color={colorPalette.textColors.neutralTextLighter}
+              />
+            </Tooltip>
+          )}
         </Typography>
       )}
     </Stack>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Tooltip from './Tooltip';
+import { IconInfoCircle } from '@tabler/icons-react';
+
+const meta: Meta<typeof Tooltip> = {
+  component: Tooltip,
+  title: 'Tooltip',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  args: {
+    title: 'Title',
+    description: 'Description',
+    direction: 'top',
+    children: <IconInfoCircle />,
+  },
+};

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,60 @@
+import { colorPalette } from '../../theme/hugo/colors';
+import { Tooltip as MuiTooltip, Stack, Typography } from '@mui/material';
+
+type TooltipBodyProps = {
+  title?: string;
+  description?: string;
+};
+
+export type TooltipProps = TooltipBodyProps & {
+  direction?: 'top' | 'left' | 'right' | 'bottom';
+  children: any;
+};
+
+const TooltipBody = ({ title, description }: TooltipBodyProps) => {
+  return (
+    <Stack sx={{ p: 1 }}>
+      <Typography
+        variant="globalS"
+        sx={{ fontWeight: 'semibold' }}
+      >
+        {title}
+      </Typography>
+      <Typography variant="globalXS">{description}</Typography>
+    </Stack>
+  );
+};
+
+const Tooltip = ({ children, ...props }: TooltipProps) => {
+  const { title = '', description = '', direction = 'top' } = props;
+  return (
+    <MuiTooltip
+      arrow
+      placement={direction}
+      sx={{
+        maxWidth: '312px',
+        minWidth: '150px',
+      }}
+      PopperProps={{
+        sx: {
+          '.MuiTooltip-tooltip': {
+            background: colorPalette.textColors.neutralText,
+          },
+          '.MuiTooltip-arrow': {
+            color: colorPalette.textColors.neutralText,
+          },
+        },
+      }}
+      title={
+        <TooltipBody
+          title={title}
+          description={description}
+        />
+      }
+    >
+      {children}
+    </MuiTooltip>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
## Summary
Se suma el componente Tooltip. No se sumo la variante `isRemovable` ya que no esta claro que es lo que remueve (parece un comportamiento mas de mobile) y no es necesario ahora en Analitics

## Screenshots, GIFs or Videos
Se suma el componente de Tooltip
<img width="1490" alt="Screenshot 2024-10-04 at 15 25 42" src="https://github.com/user-attachments/assets/e3d2e2f6-a36a-4be7-be4b-70c6eed6a463">

Se suma tooltip como posibilidad al Title
<img width="1125" alt="Screenshot 2024-10-04 at 15 25 25" src="https://github.com/user-attachments/assets/69f800d8-18e7-4521-87d1-b37eb0a07876">

## Jira Card
[Card](https://humand.atlassian.net/browse/SQXS-1485)