### PR TITLE
Add multiline to InputClassic

### DIFF
--- a/lib/components/Input/CustomInput.d.ts
+++ b/lib/components/Input/CustomInput.d.ts
@@ -1,4 +1,10 @@
 import { FC } from 'react';
-import { InputProps } from './InputClassic';
-declare const CustomInput: FC<Pick<InputProps, 'value' | 'placeholder' | 'onChange' | 'inputRef' | 'maxLength' | 'success'>>;
+import { OutlinedInputProps } from '@mui/material';
+export type CustomInputProps = Pick<OutlinedInputProps, 'placeholder' | 'inputRef' | 'multiline'> & {
+    value: string;
+    success?: boolean;
+    maxLength?: number;
+    onChange: (value: string) => void;
+};
+declare const CustomInput: FC<CustomInputProps>;
 export default CustomInput;

--- a/lib/components/Input/CustomInput.js
+++ b/lib/components/Input/CustomInput.js
@@ -2,12 +2,12 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { InputAdornment, OutlinedInput, useFormControl, useTheme, } from '@mui/material';
 import { IconAlertCircle, IconCheck, IconX } from '@tabler/icons-react';
 import { getBorderColor } from './utils';
-const CustomInput = ({ value, onChange, placeholder, inputRef, maxLength, success }) => {
+const CustomInput = ({ value, onChange, placeholder, inputRef, maxLength, success, multiline = false, }) => {
     var _a, _b, _c, _d;
     const { focused, error } = useFormControl() || {};
     const hastEndAdornment = success || error || (focused && value.length > 0);
     const theme = useTheme();
-    return (_jsx(OutlinedInput, { inputRef: inputRef, inputProps: { maxLength: maxLength }, endAdornment: hastEndAdornment && (_jsxs(InputAdornment, { position: "end", children: [focused && (_jsx(IconX, { size: 20, onMouseDown: e => {
+    return (_jsx(OutlinedInput, { inputRef: inputRef, inputProps: { maxLength }, multiline: multiline, minRows: 5, endAdornment: hastEndAdornment && (_jsxs(InputAdornment, { sx: { alignSelf: multiline ? 'flex-start' : 'center' }, position: "end", children: [focused && (_jsx(IconX, { size: 20, onMouseDown: e => {
                         onChange === null || onChange === void 0 ? void 0 : onChange('');
                         e.preventDefault();
                     }, style: { cursor: 'pointer' } })), error && (_jsx(IconAlertCircle, { size: 20, color: (_a = theme.palette.textColors) === null || _a === void 0 ? void 0 : _a.errorText })), success && (_jsx(IconCheck, { size: 20, color: (_b = theme.palette.textColors) === null || _b === void 0 ? void 0 : _b.successText }))] })), placeholder: placeholder, value: value, onChange: e => onChange(e.target.value), sx: {

--- a/lib/components/Input/CustomSelect.d.ts
+++ b/lib/components/Input/CustomSelect.d.ts
@@ -1,4 +1,13 @@
 import { FC } from 'react';
-import { Props } from './InputSelect';
-declare const CustomSelect: FC<Pick<Props, 'value' | 'onChange' | 'inputRef' | 'placeholder' | 'options'>>;
+import { SelectProps } from '@mui/material';
+export type CustomSelectProps = Pick<SelectProps, 'placeholder' | 'inputRef'> & {
+    value: string;
+    success?: boolean;
+    onChange: (value: string) => void;
+    options: {
+        label: string;
+        value: string | number;
+    }[];
+};
+declare const CustomSelect: FC<CustomSelectProps>;
 export default CustomSelect;

--- a/lib/components/Input/CustomSelect.js
+++ b/lib/components/Input/CustomSelect.js
@@ -2,7 +2,7 @@ import { jsx as _jsx } from "react/jsx-runtime";
 import { InputAdornment, MenuItem, Select, useFormControl, useTheme, } from '@mui/material';
 import { IconAlertCircle, IconChevronDown } from '@tabler/icons-react';
 import { getBorderColor } from './utils';
-const CustomSelect = ({ value, onChange, inputRef, placeholder, options }) => {
+const CustomSelect = ({ value, onChange, inputRef, placeholder, options, }) => {
     var _a, _b, _c;
     const { focused, error } = useFormControl() || {};
     const theme = useTheme();

--- a/lib/components/Input/FormInputClassic.d.ts
+++ b/lib/components/Input/FormInputClassic.d.ts
@@ -3,7 +3,7 @@ import { ControllerProps } from 'react-hook-form';
 import { ComponentProps } from 'react';
 type Props = {
     name: string;
-    inputProps: Pick<ComponentProps<typeof InputClassic>, 'label' | 'placeholder' | 'sx' | 'helperText' | 'maxLength' | 'hasCounter'>;
+    inputProps: Pick<ComponentProps<typeof InputClassic>, 'label' | 'placeholder' | 'sx' | 'helperText' | 'maxLength' | 'hasCounter' | 'multiline'>;
     rules?: ControllerProps['rules'];
 };
 declare const FormInputClassic: ({ name, inputProps, rules }: Props) => import("react/jsx-runtime").JSX.Element;

--- a/lib/components/Input/InputClassic.d.ts
+++ b/lib/components/Input/InputClassic.d.ts
@@ -1,14 +1,11 @@
-import { TextFieldProps } from '@mui/material';
-export type InputProps = Pick<TextFieldProps<'outlined'>, 'placeholder' | 'sx' | 'inputRef' | 'fullWidth'> & {
+import { FormControlProps } from '@mui/material';
+import { CustomInputProps } from './CustomInput';
+export type InputProps = Pick<FormControlProps, 'sx' | 'fullWidth'> & {
     label?: string;
     helperText?: string;
     errorText?: string;
-    value: string;
-    onChange: (v: string) => void;
     error?: boolean;
-    success?: boolean;
-    maxLength?: number;
     hasCounter?: boolean;
-};
-declare const InputClassic: ({ sx, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength, hasCounter, fullWidth, }: InputProps) => import("react/jsx-runtime").JSX.Element;
+} & CustomInputProps;
+declare const InputClassic: ({ sx, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength, hasCounter, fullWidth, multiline, }: InputProps) => import("react/jsx-runtime").JSX.Element;
 export default InputClassic;

--- a/lib/components/Input/InputClassic.js
+++ b/lib/components/Input/InputClassic.js
@@ -3,7 +3,7 @@ import { FormControl } from '@mui/material';
 import CustomLabel from './CustomLabel';
 import CustomInput from './CustomInput';
 import CustomHelperText from './CustomHelperText';
-const InputClassic = ({ sx = {}, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength = 100, hasCounter = true, fullWidth = true, }) => {
-    return (_jsxs(FormControl, { sx: sx, error: error, fullWidth: fullWidth, children: [_jsx(CustomLabel, { label: label, success: success }), _jsx(CustomInput, { value: value, onChange: onChange, placeholder: placeholder, inputRef: inputRef, maxLength: maxLength, success: success }), _jsx(CustomHelperText, { helperText: error ? errorText : helperText, hasCounter: hasCounter, maxLength: maxLength, value: value, success: success })] }));
+const InputClassic = ({ sx = {}, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength = 100, hasCounter = true, fullWidth = true, multiline, }) => {
+    return (_jsxs(FormControl, { sx: sx, error: error, fullWidth: fullWidth, children: [_jsx(CustomLabel, { label: label, success: success }), _jsx(CustomInput, { value: value, onChange: onChange, placeholder: placeholder, inputRef: inputRef, maxLength: maxLength, success: success, multiline: multiline }), _jsx(CustomHelperText, { helperText: error ? errorText : helperText, hasCounter: hasCounter, maxLength: maxLength, value: value, success: success })] }));
 };
 export default InputClassic;

--- a/lib/components/Input/InputSelect.d.ts
+++ b/lib/components/Input/InputSelect.d.ts
@@ -1,15 +1,10 @@
-import { SelectProps } from '@mui/material';
-export type Props = Pick<SelectProps<'outlined'>, 'placeholder' | 'sx' | 'inputRef' | 'fullWidth'> & {
+import { FormControlProps } from '@mui/material';
+import { CustomSelectProps } from './CustomSelect';
+export type Props = Pick<FormControlProps, 'sx' | 'fullWidth'> & CustomSelectProps & {
     label?: string;
     helperText?: string;
     errorText?: string;
-    value: string;
-    onChange: (v: string) => void;
     error?: boolean;
-    options: {
-        label: string;
-        value: string | number;
-    }[];
 };
 declare const InputSelect: ({ sx, label, value, helperText, errorText, onChange, placeholder, inputRef, error, fullWidth, options, }: Props) => import("react/jsx-runtime").JSX.Element;
 export default InputSelect;

--- a/src/components/Input/CustomInput.tsx
+++ b/src/components/Input/CustomInput.tsx
@@ -1,20 +1,33 @@
 import { FC } from 'react';
-import { InputProps } from './InputClassic';
 import {
   InputAdornment,
   OutlinedInput,
+  OutlinedInputProps,
   useFormControl,
   useTheme,
 } from '@mui/material';
 import { IconAlertCircle, IconCheck, IconX } from '@tabler/icons-react';
 import { getBorderColor } from './utils';
 
-const CustomInput: FC<
-  Pick<
-    InputProps,
-    'value' | 'placeholder' | 'onChange' | 'inputRef' | 'maxLength' | 'success'
-  >
-> = ({ value, onChange, placeholder, inputRef, maxLength, success }) => {
+export type CustomInputProps = Pick<
+  OutlinedInputProps,
+  'placeholder' | 'inputRef' | 'multiline'
+> & {
+  value: string;
+  success?: boolean;
+  maxLength?: number;
+  onChange: (value: string) => void;
+};
+
+const CustomInput: FC<CustomInputProps> = ({
+  value,
+  onChange,
+  placeholder,
+  inputRef,
+  maxLength,
+  success,
+  multiline = false,
+}) => {
   const { focused, error } = useFormControl() || {};
   const hastEndAdornment = success || error || (focused && value.length > 0);
   const theme = useTheme();
@@ -22,10 +35,15 @@ const CustomInput: FC<
   return (
     <OutlinedInput
       inputRef={inputRef}
-      inputProps={{ maxLength: maxLength }}
+      inputProps={{ maxLength }}
+      multiline={multiline}
+      minRows={5}
       endAdornment={
         hastEndAdornment && (
-          <InputAdornment position="end">
+          <InputAdornment
+            sx={{ alignSelf: multiline ? 'flex-start' : 'center' }}
+            position="end"
+          >
             {focused && (
               <IconX
                 size={20}

--- a/src/components/Input/CustomSelect.tsx
+++ b/src/components/Input/CustomSelect.tsx
@@ -3,16 +3,30 @@ import {
   InputAdornment,
   MenuItem,
   Select,
+  SelectProps,
   useFormControl,
   useTheme,
 } from '@mui/material';
 import { IconAlertCircle, IconChevronDown } from '@tabler/icons-react';
 import { getBorderColor } from './utils';
-import { Props } from './InputSelect';
 
-const CustomSelect: FC<
-  Pick<Props, 'value' | 'onChange' | 'inputRef' | 'placeholder' | 'options'>
-> = ({ value, onChange, inputRef, placeholder, options }) => {
+export type CustomSelectProps = Pick<
+  SelectProps,
+  'placeholder' | 'inputRef'
+> & {
+  value: string;
+  success?: boolean;
+  onChange: (value: string) => void;
+  options: { label: string; value: string | number }[];
+};
+
+const CustomSelect: FC<CustomSelectProps> = ({
+  value,
+  onChange,
+  inputRef,
+  placeholder,
+  options,
+}) => {
   const { focused, error } = useFormControl() || {};
   const theme = useTheme();
   return (

--- a/src/components/Input/FormInputClassic.tsx
+++ b/src/components/Input/FormInputClassic.tsx
@@ -6,7 +6,13 @@ type Props = {
   name: string;
   inputProps: Pick<
     ComponentProps<typeof InputClassic>,
-    'label' | 'placeholder' | 'sx' | 'helperText' | 'maxLength' | 'hasCounter'
+    | 'label'
+    | 'placeholder'
+    | 'sx'
+    | 'helperText'
+    | 'maxLength'
+    | 'hasCounter'
+    | 'multiline'
   >;
   rules?: ControllerProps['rules'];
 };

--- a/src/components/Input/InputClassic.stories.tsx
+++ b/src/components/Input/InputClassic.stories.tsx
@@ -74,3 +74,27 @@ export const FormInputClassicStory: Story = {
     );
   },
 };
+
+export const FormInputClassicMultilineStory: Story = {
+  render: () => {
+    const form = useForm({
+      defaultValues: {
+        myInput: '',
+      },
+    });
+    return (
+      <FormProvider {...form}>
+        <FormInputClassic
+          inputProps={{
+            placeholder: 'Placeholder',
+            label: 'Label',
+            helperText: 'HelperText',
+            hasCounter: true,
+            multiline: true,
+          }}
+          name="myInput"
+        />
+      </FormProvider>
+    );
+  },
+};

--- a/src/components/Input/InputClassic.tsx
+++ b/src/components/Input/InputClassic.tsx
@@ -1,22 +1,15 @@
-import { FormControl, TextFieldProps } from '@mui/material';
+import { FormControl, FormControlProps } from '@mui/material';
 import CustomLabel from './CustomLabel';
-import CustomInput from './CustomInput';
+import CustomInput, { CustomInputProps } from './CustomInput';
 import CustomHelperText from './CustomHelperText';
 
-export type InputProps = Pick<
-  TextFieldProps<'outlined'>,
-  'placeholder' | 'sx' | 'inputRef' | 'fullWidth'
-> & {
+export type InputProps = Pick<FormControlProps, 'sx' | 'fullWidth'> & {
   label?: string;
   helperText?: string;
   errorText?: string;
-  value: string;
-  onChange: (v: string) => void;
   error?: boolean;
-  success?: boolean;
-  maxLength?: number;
   hasCounter?: boolean;
-};
+} & CustomInputProps;
 
 const InputClassic = ({
   sx = {},
@@ -32,6 +25,7 @@ const InputClassic = ({
   maxLength = 100,
   hasCounter = true,
   fullWidth = true,
+  multiline,
 }: InputProps) => {
   return (
     <FormControl
@@ -50,6 +44,7 @@ const InputClassic = ({
         inputRef={inputRef}
         maxLength={maxLength}
         success={success}
+        multiline={multiline}
       />
       <CustomHelperText
         helperText={error ? errorText : helperText}

--- a/src/components/Input/InputSelect.tsx
+++ b/src/components/Input/InputSelect.tsx
@@ -1,20 +1,15 @@
-import { FormControl, SelectProps } from '@mui/material';
+import { FormControl, FormControlProps } from '@mui/material';
 import CustomLabel from './CustomLabel';
 import CustomHelperText from './CustomHelperText';
-import CustomSelect from './CustomSelect';
+import CustomSelect, { CustomSelectProps } from './CustomSelect';
 
-export type Props = Pick<
-  SelectProps<'outlined'>,
-  'placeholder' | 'sx' | 'inputRef' | 'fullWidth'
-> & {
-  label?: string;
-  helperText?: string;
-  errorText?: string;
-  value: string;
-  onChange: (v: string) => void;
-  error?: boolean;
-  options: { label: string; value: string | number }[];
-};
+export type Props = Pick<FormControlProps, 'sx' | 'fullWidth'> &
+  CustomSelectProps & {
+    label?: string;
+    helperText?: string;
+    errorText?: string;
+    error?: boolean;
+  };
 
 const InputSelect = ({
   sx = {},


### PR DESCRIPTION
## Summary
Agrego opcion multiline al inputclassic.
Tambien muevo de lugar algunos types para que el input en sí no dependa de las props del wrapper que tiene label+input+helper

## Screenshots, GIFs or Videos
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/6321d06a-a2b0-4641-816f-a1fcec2fc173">


## Jira Card
https://humand.atlassian.net/browse/SQJG-2906