### PR TITLE
Server pagination | Add default values

### DIFF
--- a/lib/hooks/useServerPagination.d.ts
+++ b/lib/hooks/useServerPagination.d.ts
@@ -17,6 +17,9 @@ type ServerPaginationOptions = {
     labelRowsPerPage?: string;
     defaultOrderBy?: string;
     defaultOrder?: string;
+    defaultPage?: number;
+    defaultLimit?: number;
+    defaultQuery?: string;
     limitOptions?: number[];
 };
 declare const useServerPagination: (options?: ServerPaginationOptions) => {

--- a/lib/hooks/useServerPagination.js
+++ b/lib/hooks/useServerPagination.js
@@ -34,13 +34,13 @@ const useServerTableSorting = (form) => {
 };
 const useServerPagination = (options) => {
     const { labelRowsPerPage = '', // Depends if paginationController is used
-    defaultOrderBy = 'CREATED_AT', defaultOrder = 'ASC', limitOptions = [10, 20, 30], } = options !== null && options !== void 0 ? options : {};
+    defaultOrderBy = 'CREATED_AT', defaultOrder = 'ASC', defaultPage = 0, defaultLimit = 10, defaultQuery = '', limitOptions = [10, 20, 30], } = options !== null && options !== void 0 ? options : {};
     const form = useForm({
         defaultValues: {
-            query: '',
+            query: defaultQuery,
             pagination: {
-                page: 0,
-                limit: limitOptions[0],
+                page: defaultPage,
+                limit: defaultLimit === limitOptions[0] ? defaultLimit : limitOptions[0],
             },
             order: defaultOrder,
             orderBy: defaultOrderBy,

--- a/lib/hooks/useServerPagination.js
+++ b/lib/hooks/useServerPagination.js
@@ -40,7 +40,7 @@ const useServerPagination = (options) => {
             query: defaultQuery,
             pagination: {
                 page: defaultPage,
-                limit: defaultLimit === limitOptions[0] ? defaultLimit : limitOptions[0],
+                limit: defaultLimit === limitOptions[0] ? limitOptions[0] : defaultLimit,
             },
             order: defaultOrder,
             orderBy: defaultOrderBy,

--- a/src/hooks/useServerPagination.tsx
+++ b/src/hooks/useServerPagination.tsx
@@ -64,6 +64,9 @@ type ServerPaginationOptions = {
   labelRowsPerPage?: string;
   defaultOrderBy?: string;
   defaultOrder?: string;
+  defaultPage?: number;
+  defaultLimit?: number;
+  defaultQuery?: string;
   limitOptions?: number[];
 };
 
@@ -72,15 +75,19 @@ const useServerPagination = (options?: ServerPaginationOptions) => {
     labelRowsPerPage = '', // Depends if paginationController is used
     defaultOrderBy = 'CREATED_AT',
     defaultOrder = 'ASC',
+    defaultPage = 0,
+    defaultLimit = 10,
+    defaultQuery = '',
     limitOptions = [10, 20, 30],
   } = options ?? {};
 
   const form = useForm<FormValues>({
     defaultValues: {
-      query: '',
+      query: defaultQuery,
       pagination: {
-        page: 0,
-        limit: limitOptions[0],
+        page: defaultPage,
+        limit:
+          defaultLimit === limitOptions[0] ? defaultLimit : limitOptions[0],
       },
       order: defaultOrder,
       orderBy: defaultOrderBy,

--- a/src/hooks/useServerPagination.tsx
+++ b/src/hooks/useServerPagination.tsx
@@ -87,7 +87,7 @@ const useServerPagination = (options?: ServerPaginationOptions) => {
       pagination: {
         page: defaultPage,
         limit:
-          defaultLimit === limitOptions[0] ? defaultLimit : limitOptions[0],
+          defaultLimit === limitOptions[0] ? limitOptions[0] : defaultLimit,
       },
       order: defaultOrder,
       orderBy: defaultOrderBy,


### PR DESCRIPTION
## Summary
Se agregan los parametros `defaultQuery`, `defaultLimit` y `defaultPage` al hook `useServerPagination` para poder configurar estos valores en caso de que no sean los defaults. Por ej., para guardar valores de paginacion en la URL y setterar los valores iniciales correctos.