### PR TITLE
[NO-CARD] Breadcrumbs | Links with onClick

### DIFF
--- a/lib/components/Breadcrumbs/Breadcrumbs.js
+++ b/lib/components/Breadcrumbs/Breadcrumbs.js
@@ -1,13 +1,14 @@
 import { jsxs as _jsxs, jsx as _jsx } from "react/jsx-runtime";
-import { Box, Link, Breadcrumbs as MuiBreadcrumbs, Typography, useTheme, } from '@mui/material';
+import { Stack, Breadcrumbs as MuiBreadcrumbs, Typography, useTheme, } from '@mui/material';
+import Link from '../Link/Link';
 import { useMemo } from 'react';
 import { CustomCollapsedIcon } from './CustomCollapsedIcon';
 import React from 'react';
 const LinkBox = ({ children, darkBackground, breadcrumbIcon, }) => {
     var _a, _b;
     const theme = useTheme();
-    return (_jsxs(Box, { sx: {
-            display: 'flex',
+    return (_jsxs(Stack, { sx: {
+            flexDirection: 'row',
             alignItems: 'center',
         }, children: [children, breadcrumbIcon
                 ? React.createElement(breadcrumbIcon, {
@@ -44,9 +45,9 @@ const BreadCrumbs = ({ links, darkBackground }) => {
         // @ts-ignore - Mui does not recognize the CustomCollapsedIcon props
         slotProps: { collapsedIcon: { collapsedLinks, darkBackground } }, children: links.map((link, index) => {
             var _a, _b, _c;
-            return (_jsx(LinkBox, { breadcrumbIcon: link.icon, darkBackground: darkBackground, children: index < links.length - 1 ? (_jsx(Link, { color: darkBackground ? (_a = theme.palette.base) === null || _a === void 0 ? void 0 : _a.white : 'primary.main', href: link.href, children: link.title })) : (_jsx(Typography, { variant: "globalS", color: darkBackground
-                        ? (_b = theme.palette.base) === null || _b === void 0 ? void 0 : _b.white
-                        : (_c = theme.palette.base) === null || _c === void 0 ? void 0 : _c.grey[800], children: link.title })) }, index));
+            return (_jsxs(LinkBox, { breadcrumbIcon: link.icon, darkBackground: darkBackground, children: [index < links.length - 1 && (_jsx(Link, { color: darkBackground ? (_a = theme.palette.base) === null || _a === void 0 ? void 0 : _a.white : 'primary.main', href: link.href, onClick: link.onClick, children: link.title })), index === links.length - 1 && (_jsx(Typography, { variant: "globalS", color: darkBackground
+                            ? (_b = theme.palette.base) === null || _b === void 0 ? void 0 : _b.white
+                            : (_c = theme.palette.base) === null || _c === void 0 ? void 0 : _c.grey[800], children: link.title }))] }, index));
         }) }));
 };
 export default BreadCrumbs;

--- a/lib/components/Breadcrumbs/types.d.ts
+++ b/lib/components/Breadcrumbs/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="react" />
-export type BreadcrumbLink = {
+import { LinkProps } from '../Link/Link';
+export type BreadcrumbLink = Pick<LinkProps, 'href' | 'onClick'> & {
     title: string;
-    href: string;
     icon?: React.ElementType;
 };

--- a/lib/components/Link/Link.d.ts
+++ b/lib/components/Link/Link.d.ts
@@ -1,10 +1,9 @@
-import { LinkProps, SxProps } from '@mui/material';
+import { LinkProps as MuiLinkProps } from '@mui/material';
 import { FC, PropsWithChildren } from 'react';
-type Props = {
+export type LinkProps = {
     hasIcon?: boolean;
     iconSize?: number;
     disabled?: boolean;
-    sx?: SxProps;
-} & Omit<LinkProps, 'sx'>;
-declare const Link: FC<PropsWithChildren<Props>>;
+} & MuiLinkProps;
+export declare const Link: FC<PropsWithChildren<LinkProps>>;
 export default Link;

--- a/lib/components/Link/Link.js
+++ b/lib/components/Link/Link.js
@@ -13,7 +13,7 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Link as MuiLink, Stack, useTheme, } from '@mui/material';
 import { IconArrowNarrowRight } from '@tabler/icons-react';
 import { colorPalette } from '../../theme/hugo/colors';
-const Link = (_a) => {
+export const Link = (_a) => {
     var { children, hasIcon = false, iconSize = 16, disabled = false, sx = {} } = _a, props = __rest(_a, ["children", "hasIcon", "iconSize", "disabled", "sx"]);
     const theme = useTheme();
     const handleClick = (e) => {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,10 +1,10 @@
 import {
-  Box,
-  Link,
+  Stack,
   Breadcrumbs as MuiBreadcrumbs,
   Typography,
   useTheme,
 } from '@mui/material';
+import Link from '../Link/Link';
 import { useMemo } from 'react';
 import { CustomCollapsedIcon } from './CustomCollapsedIcon';
 import { BreadcrumbLink } from './types';
@@ -15,6 +15,7 @@ type LinkBoxProps = {
   darkBackground?: boolean;
   breadcrumbIcon?: BreadcrumbLink['icon'];
 };
+
 const LinkBox = ({
   children,
   darkBackground,
@@ -22,9 +23,9 @@ const LinkBox = ({
 }: LinkBoxProps) => {
   const theme = useTheme();
   return (
-    <Box
+    <Stack
       sx={{
-        display: 'flex',
+        flexDirection: 'row',
         alignItems: 'center',
       }}
     >
@@ -42,7 +43,7 @@ const LinkBox = ({
             },
           })
         : null}
-    </Box>
+    </Stack>
   );
 };
 
@@ -93,16 +94,18 @@ const BreadCrumbs = ({ links, darkBackground }: Props) => {
           breadcrumbIcon={link.icon}
           darkBackground={darkBackground}
         >
-          {index < links.length - 1 ? (
+          {index < links.length - 1 && (
             <Link
               color={
                 darkBackground ? theme.palette.base?.white : 'primary.main'
               }
               href={link.href}
+              onClick={link.onClick}
             >
               {link.title}
             </Link>
-          ) : (
+          )}
+          {index === links.length - 1 && (
             <Typography
               variant="globalS"
               color={

--- a/src/components/Breadcrumbs/types.ts
+++ b/src/components/Breadcrumbs/types.ts
@@ -1,5 +1,6 @@
-export type BreadcrumbLink = {
+import { LinkProps } from '../Link/Link';
+
+export type BreadcrumbLink = Pick<LinkProps, 'href' | 'onClick'> & {
   title: string;
-  href: string;
   icon?: React.ElementType;
 };

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,22 +1,20 @@
 import {
-  LinkProps,
+  LinkProps as MuiLinkProps,
   Link as MuiLink,
   Stack,
-  SxProps,
   useTheme,
 } from '@mui/material';
 import { FC, PropsWithChildren } from 'react';
 import { IconArrowNarrowRight } from '@tabler/icons-react';
 import { colorPalette } from '../../theme/hugo/colors';
 
-type Props = {
+export type LinkProps = {
   hasIcon?: boolean;
   iconSize?: number;
   disabled?: boolean;
-  sx?: SxProps;
-} & Omit<LinkProps, 'sx'>;
+} & MuiLinkProps;
 
-const Link: FC<PropsWithChildren<Props>> = ({
+export const Link: FC<PropsWithChildren<LinkProps>> = ({
   children,
   hasIcon = false,
   iconSize = 16,


### PR DESCRIPTION
## Summary
- Se agrega la opción de tener los links de breadcrumbs con `onClick` en vez de `href`.