### PR TITLE
[SQSH-1819] Add switcher

### DIFF
--- a/lib/components/Switcher/Switcher.d.ts
+++ b/lib/components/Switcher/Switcher.d.ts
@@ -1,0 +1,10 @@
+import { FC } from 'react';
+import { ChipProps } from '../Toggle/Toggle';
+type SwitcherProps = {
+    title: string;
+    description: string;
+    disabled?: boolean;
+    toggleProps?: ChipProps;
+};
+declare const Switcher: FC<SwitcherProps>;
+export default Switcher;

--- a/lib/components/Switcher/Switcher.js
+++ b/lib/components/Switcher/Switcher.js
@@ -1,0 +1,21 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import Toggle from '../Toggle/Toggle';
+import { Stack, Typography, useTheme } from '@mui/material';
+const Switcher = props => {
+    const { title, description, disabled: disabledProp = false, toggleProps, } = props;
+    const disabled = disabledProp || (toggleProps === null || toggleProps === void 0 ? void 0 : toggleProps.disabled);
+    const theme = useTheme();
+    const textColors = theme.palette.textColors;
+    const colors = {
+        title: disabled ? textColors === null || textColors === void 0 ? void 0 : textColors.neutralTextDisabled : textColors === null || textColors === void 0 ? void 0 : textColors.neutralText,
+        description: disabled
+            ? textColors === null || textColors === void 0 ? void 0 : textColors.neutralTextDisabled
+            : textColors === null || textColors === void 0 ? void 0 : textColors.neutralTextLighter,
+    };
+    return (_jsxs(Stack, { sx: {
+            flexDirection: 'row',
+            width: '292px',
+            justifyContent: 'space-between',
+        }, children: [_jsxs(Stack, { children: [_jsx(Typography, { variant: "globalS", color: colors.title, children: title }), _jsx(Typography, { variant: "globalXS", color: colors.description, children: description })] }), _jsx(Stack, { sx: { justifyContent: 'center' }, children: _jsx(Toggle, Object.assign({}, toggleProps, { disabled: disabled })) })] }));
+};
+export default Switcher;

--- a/lib/components/Toggle/Toggle.d.ts
+++ b/lib/components/Toggle/Toggle.d.ts
@@ -1,4 +1,4 @@
 import { SwitchProps as MuiSwitchProps } from '@mui/material';
-export type ChipProps = Pick<MuiSwitchProps, 'disabled'>;
-declare const Toggle: ({ disabled }: MuiSwitchProps) => import("react/jsx-runtime").JSX.Element;
+export type ChipProps = Pick<MuiSwitchProps, 'disabled' | 'defaultChecked'>;
+declare const Toggle: ({ disabled, defaultChecked }: ChipProps) => import("react/jsx-runtime").JSX.Element;
 export default Toggle;

--- a/lib/components/Toggle/Toggle.js
+++ b/lib/components/Toggle/Toggle.js
@@ -1,10 +1,10 @@
 import { jsx as _jsx } from "react/jsx-runtime";
 import { Switch as MuiSwitch, useTheme, } from '@mui/material';
 import { colorPalette } from '../../theme/hugo/colors';
-const Toggle = ({ disabled }) => {
+const Toggle = ({ disabled, defaultChecked }) => {
     const { hugoBackground, buttons, border, ilustrations } = colorPalette;
     const theme = useTheme();
-    return (_jsx(MuiSwitch, { disableRipple: true, disabled: disabled, sx: {
+    return (_jsx(MuiSwitch, { disableRipple: true, disabled: disabled, defaultChecked: defaultChecked, sx: {
             width: 52,
             height: 32,
             padding: 0,

--- a/lib/huexports.d.ts
+++ b/lib/huexports.d.ts
@@ -34,3 +34,4 @@ export { default as HuUseSnackbar } from './components/Snackbar/Snackbar';
 export { default as HuLink } from './components/Link/Link';
 export { default as HuDialog } from './components/Dialog/Dialog';
 export { default as HuDropdown } from './components/Dropdown/Dropdown';
+export { default as HuSwitcher } from './components/Switcher/Switcher';

--- a/lib/huexports.js
+++ b/lib/huexports.js
@@ -34,3 +34,4 @@ export { default as HuUseSnackbar } from './components/Snackbar/Snackbar';
 export { default as HuLink } from './components/Link/Link';
 export { default as HuDialog } from './components/Dialog/Dialog';
 export { default as HuDropdown } from './components/Dropdown/Dropdown';
+export { default as HuSwitcher } from './components/Switcher/Switcher';

--- a/src/components/Switcher/Switcher.stories.tsx
+++ b/src/components/Switcher/Switcher.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryObj } from '@storybook/react/*';
+import Switcher from './Switcher';
+
+const meta: Meta<typeof Switcher> = {
+  component: Switcher,
+  title: 'Switcher',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Switcher>;
+
+const exampleTitle = 'Chocolate';
+const exampleDescription = 'Toggle if you like chocolate';
+
+export const Default: Story = {
+  args: {
+    title: exampleTitle,
+    description: exampleDescription,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    title: exampleTitle,
+    description: exampleDescription,
+    disabled: true,
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    title: exampleTitle,
+    description: exampleDescription,
+    toggleProps: {
+      defaultChecked: true,
+    },
+  },
+};

--- a/src/components/Switcher/Switcher.tsx
+++ b/src/components/Switcher/Switcher.tsx
@@ -1,0 +1,61 @@
+import { FC } from 'react';
+import Toggle, { ChipProps } from '../Toggle/Toggle';
+import { Stack, Typography, useTheme } from '@mui/material';
+
+type SwitcherProps = {
+  title: string;
+  description: string;
+  disabled?: boolean;
+  toggleProps?: ChipProps;
+};
+const Switcher: FC<SwitcherProps> = props => {
+  const {
+    title,
+    description,
+    disabled: disabledProp = false,
+    toggleProps,
+  } = props;
+
+  const disabled = disabledProp || toggleProps?.disabled;
+  const theme = useTheme();
+  const textColors = theme.palette.textColors;
+  const colors = {
+    title: disabled ? textColors?.neutralTextDisabled : textColors?.neutralText,
+    description: disabled
+      ? textColors?.neutralTextDisabled
+      : textColors?.neutralTextLighter,
+  };
+
+  return (
+    <Stack
+      sx={{
+        flexDirection: 'row',
+        width: '292px',
+        justifyContent: 'space-between',
+      }}
+    >
+      <Stack>
+        <Typography
+          variant="globalS"
+          color={colors.title}
+        >
+          {title}
+        </Typography>
+        <Typography
+          variant="globalXS"
+          color={colors.description}
+        >
+          {description}
+        </Typography>
+      </Stack>
+      <Stack sx={{ justifyContent: 'center' }}>
+        <Toggle
+          {...toggleProps}
+          disabled={disabled}
+        />
+      </Stack>
+    </Stack>
+  );
+};
+
+export default Switcher;

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -5,15 +5,16 @@ import {
 } from '@mui/material';
 import { colorPalette } from '../../theme/hugo/colors';
 
-export type ChipProps = Pick<MuiSwitchProps, 'disabled'>;
+export type ChipProps = Pick<MuiSwitchProps, 'disabled' | 'defaultChecked'>;
 
-const Toggle = ({ disabled }: MuiSwitchProps) => {
+const Toggle = ({ disabled, defaultChecked }: ChipProps) => {
   const { hugoBackground, buttons, border, ilustrations } = colorPalette;
   const theme = useTheme();
   return (
     <MuiSwitch
       disableRipple
       disabled={disabled}
+      defaultChecked={defaultChecked}
       sx={{
         width: 52,
         height: 32,

--- a/src/huexports.ts
+++ b/src/huexports.ts
@@ -34,3 +34,4 @@ export { default as HuUseSnackbar } from './components/Snackbar/Snackbar';
 export { default as HuLink } from './components/Link/Link';
 export { default as HuDialog } from './components/Dialog/Dialog';
 export { default as HuDropdown } from './components/Dropdown/Dropdown';
+export { default as HuSwitcher } from './components/Switcher/Switcher';


### PR DESCRIPTION
## Summary
Note: dark mode will be put on hold. It should be automatic once a global dark mode pallette is implemented

## Screenshots, GIFs or Videos
<img width="332" alt="image" src="https://github.com/user-attachments/assets/7f3e08a3-b8ba-4c32-b52e-6a581a064a37">
<img width="334" alt="image" src="https://github.com/user-attachments/assets/6e424430-6f1a-440e-809f-d26c5a2613ab">
<img width="316" alt="image" src="https://github.com/user-attachments/assets/ae4bd26d-f8f4-4a03-8dd8-9d1e39ea858e">


## Jira Card
[SQSH-1819](https://humand.atlassian.net/browse/SQSH-1819)

[SQSH-1819]: https://humand.atlassian.net/browse/SQSH-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ