### PR TITLE
[-] Improvements Snackbar & ButtonGroup

### DIFF
--- a/lib/components/ButtonGroup/ButtonGroup.d.ts
+++ b/lib/components/ButtonGroup/ButtonGroup.d.ts
@@ -2,7 +2,7 @@ export type ButtonGroupProps = {
     labels: [string, string] | [string, string, string];
     onChange?: (index: number) => void;
     fullWidth?: boolean;
-    disableDoubleClick?: boolean;
+    disableUnselect?: boolean;
 };
-declare const ButtonGroup: ({ labels, onChange, fullWidth, disableDoubleClick, }: ButtonGroupProps) => import("react/jsx-runtime").JSX.Element;
+declare const ButtonGroup: ({ labels, onChange, fullWidth, disableUnselect, }: ButtonGroupProps) => import("react/jsx-runtime").JSX.Element;
 export default ButtonGroup;

--- a/lib/components/ButtonGroup/ButtonGroup.d.ts
+++ b/lib/components/ButtonGroup/ButtonGroup.d.ts
@@ -2,6 +2,7 @@ export type ButtonGroupProps = {
     labels: [string, string] | [string, string, string];
     onChange?: (index: number) => void;
     fullWidth?: boolean;
+    disableDoubleClick?: boolean;
 };
-declare const ButtonGroup: ({ labels, onChange, fullWidth, }: ButtonGroupProps) => import("react/jsx-runtime").JSX.Element;
+declare const ButtonGroup: ({ labels, onChange, fullWidth, disableDoubleClick, }: ButtonGroupProps) => import("react/jsx-runtime").JSX.Element;
 export default ButtonGroup;

--- a/lib/components/ButtonGroup/ButtonGroup.js
+++ b/lib/components/ButtonGroup/ButtonGroup.js
@@ -2,10 +2,14 @@ import { jsx as _jsx } from "react/jsx-runtime";
 import { Button, ButtonGroup as MUIButtonGroup, useTheme } from '@mui/material';
 import { IconCheck } from '@tabler/icons-react';
 import { useState } from 'react';
-const ButtonGroup = ({ labels, onChange, fullWidth = false, }) => {
+const ButtonGroup = ({ labels, onChange, fullWidth = false, disableDoubleClick = false, }) => {
     const [selectedButton, setSelectedButton] = useState(0);
     const buttonSelection = (index) => {
-        setSelectedButton(prevSelected => (prevSelected === index ? null : index));
+        setSelectedButton(prevSelected => {
+            if (disableDoubleClick)
+                return index;
+            return prevSelected === index ? null : index;
+        });
         onChange === null || onChange === void 0 ? void 0 : onChange(index);
     };
     const { palette: { base }, } = useTheme();

--- a/lib/components/ButtonGroup/ButtonGroup.js
+++ b/lib/components/ButtonGroup/ButtonGroup.js
@@ -2,15 +2,17 @@ import { jsx as _jsx } from "react/jsx-runtime";
 import { Button, ButtonGroup as MUIButtonGroup, useTheme } from '@mui/material';
 import { IconCheck } from '@tabler/icons-react';
 import { useState } from 'react';
-const ButtonGroup = ({ labels, onChange, fullWidth = false, disableDoubleClick = false, }) => {
+const ButtonGroup = ({ labels, onChange, fullWidth = false, disableUnselect = false, }) => {
     const [selectedButton, setSelectedButton] = useState(0);
     const buttonSelection = (index) => {
-        setSelectedButton(prevSelected => {
-            if (disableDoubleClick)
-                return index;
-            return prevSelected === index ? null : index;
-        });
-        onChange === null || onChange === void 0 ? void 0 : onChange(index);
+        const newIndex = selectedButton === index ? null : index;
+        const newSelected = disableUnselect ? index : newIndex;
+        setSelectedButton(newSelected);
+        // Execute onChange if its enabled Unselect or if its a different button
+        if (!disableUnselect ||
+            (disableUnselect && newSelected !== selectedButton)) {
+            onChange === null || onChange === void 0 ? void 0 : onChange(index);
+        }
     };
     const { palette: { base }, } = useTheme();
     return (_jsx(MUIButtonGroup, { variant: "outlined", sx: { display: 'flex', width: fullWidth ? '100%' : 'auto' }, children: labels.map((label, index) => (_jsx(Button, { onClick: () => buttonSelection(index), sx: {

--- a/lib/components/Snackbar/Snackbar.js
+++ b/lib/components/Snackbar/Snackbar.js
@@ -59,7 +59,7 @@ export const useSnackbar = () => {
                                 alignItems: 'center',
                                 gap: 1,
                                 ml: 1,
-                                maxWidth: 360,
+                                maxWidth: cancelAction ? 400 : '98%',
                             }, children: [_jsx(Badge, { badgeContent: _jsx(Box, { sx: {
                                             width: 16,
                                             height: 16,
@@ -67,7 +67,7 @@ export const useSnackbar = () => {
                                             alignItems: 'center',
                                         }, children: _jsx(Icon, {}) }), overlap: "circular", sx: {
                                         mr: 2,
-                                        mb: description ? 2 : 0,
+                                        mb: title && description ? 2 : 0,
                                         '.MuiBadge-badge': {
                                             backgroundColor: iconColor,
                                             minWidth: 24,
@@ -84,7 +84,7 @@ export const useSnackbar = () => {
                                     mr: 4,
                                     color: 'white',
                                     minWidth: 'auto',
-                                    maxWidth: 150,
+                                    maxWidth: 130,
                                 }, children: _jsx(Typography, { variant: "globalS", color: "white", fontWeight: "fontWeightRegular", sx: { textDecoration: 'underline', textTransform: 'none' }, children: cancelAction.text }) })),
                             hasClose && (_jsx(IconButton, { color: "inherit", onClick: () => closeSnackbar(key), sx: {
                                     p: 0,

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -9,6 +9,7 @@ const meta: Meta<typeof ButtonGroup> = {
   args: {
     labels: ['Button 1', 'Button 2'],
     fullWidth: false,
+    disableDoubleClick: false,
   },
   argTypes: {},
 };
@@ -30,6 +31,13 @@ export const Two: Story = {
 export const Three: Story = {
   args: {
     labels: ['Button 1', 'Button 2', 'Button 3'],
+  },
+};
+
+export const DisabledDoubleClick: Story = {
+  args: {
+    labels: ['Button 1', 'Button 2', 'Button 3'],
+    disableDoubleClick: true,
   },
 };
 

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof ButtonGroup> = {
   args: {
     labels: ['Button 1', 'Button 2'],
     fullWidth: false,
-    disableDoubleClick: false,
+    disableUnselect: false,
   },
   argTypes: {},
 };
@@ -34,10 +34,11 @@ export const Three: Story = {
   },
 };
 
-export const DisabledDoubleClick: Story = {
+export const DisabledUnselect: Story = {
   args: {
     labels: ['Button 1', 'Button 2', 'Button 3'],
-    disableDoubleClick: true,
+    disableUnselect: true,
+    onChange: index => alert(`You have clicked ${index + 1}`),
   },
 };
 

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -6,23 +6,29 @@ export type ButtonGroupProps = {
   labels: [string, string] | [string, string, string]; // Min 3 buttons - Max 3 buttons
   onChange?: (index: number) => void;
   fullWidth?: boolean;
-  disableDoubleClick?: boolean;
+  disableUnselect?: boolean;
 };
 
 const ButtonGroup = ({
   labels,
   onChange,
   fullWidth = false,
-  disableDoubleClick = false,
+  disableUnselect = false,
 }: ButtonGroupProps) => {
   const [selectedButton, setSelectedButton] = useState<number | null>(0);
 
   const buttonSelection = (index: number) => {
-    setSelectedButton(prevSelected => {
-      if (disableDoubleClick) return index;
-      return prevSelected === index ? null : index;
-    });
-    onChange?.(index);
+    const newIndex = selectedButton === index ? null : index;
+    const newSelected = disableUnselect ? index : newIndex;
+    setSelectedButton(newSelected);
+
+    // Execute onChange if its enabled Unselect or if its a different button
+    if (
+      !disableUnselect ||
+      (disableUnselect && newSelected !== selectedButton)
+    ) {
+      onChange?.(index);
+    }
   };
 
   const {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -6,17 +6,22 @@ export type ButtonGroupProps = {
   labels: [string, string] | [string, string, string]; // Min 3 buttons - Max 3 buttons
   onChange?: (index: number) => void;
   fullWidth?: boolean;
+  disableDoubleClick?: boolean;
 };
 
 const ButtonGroup = ({
   labels,
   onChange,
   fullWidth = false,
+  disableDoubleClick = false,
 }: ButtonGroupProps) => {
   const [selectedButton, setSelectedButton] = useState<number | null>(0);
 
   const buttonSelection = (index: number) => {
-    setSelectedButton(prevSelected => (prevSelected === index ? null : index));
+    setSelectedButton(prevSelected => {
+      if (disableDoubleClick) return index;
+      return prevSelected === index ? null : index;
+    });
     onChange?.(index);
   };
 

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -111,7 +111,7 @@ export const useSnackbar = () => {
                   alignItems: 'center',
                   gap: 1,
                   ml: 1,
-                  maxWidth: 360,
+                  maxWidth: cancelAction ? 400 : '98%',
                 }}
               >
                 <Badge
@@ -130,7 +130,7 @@ export const useSnackbar = () => {
                   overlap="circular"
                   sx={{
                     mr: 2,
-                    mb: description ? 2 : 0,
+                    mb: title && description ? 2 : 0,
                     '.MuiBadge-badge': {
                       backgroundColor: iconColor,
                       minWidth: 24,
@@ -174,7 +174,7 @@ export const useSnackbar = () => {
                     mr: 4,
                     color: 'white',
                     minWidth: 'auto',
-                    maxWidth: 150,
+                    maxWidth: 130,
                   }}
                 >
                   <Typography


### PR DESCRIPTION
## Summary
Usando Snackbar & ButtonGroup en una nueva feature, se encontraron 2 cosas:
- ButtonGroup: Falta la posibilidad de hacerse click en la opcion seleccionada y que no quede ninguna
- Snackbar: Considerar caso en que se use **description** sin **title** y haya desalineaciones / desperdicio de espacios, y lo mismo para aprovechar todo el ancho si no hay `Cancel Action`

## Screenshots, GIFs or Videos
<img width="617" alt="Screenshot 2024-11-11 at 5 01 50 PM" src="https://github.com/user-attachments/assets/9c267b6e-32ff-4c02-b999-563743bb93c5">
<img width="617" alt="Screenshot 2024-11-11 at 5 27 57 PM" src="https://github.com/user-attachments/assets/c25224ec-7dc8-40bd-91ac-359332c91be9">
