### PR TITLE
[NO-CARD] Title | Ajustar alignment de tooltips

### DIFF
--- a/lib/components/Title/Title.js
+++ b/lib/components/Title/Title.js
@@ -34,7 +34,7 @@ const adjustedDescription = {
     S: 'globalXS',
 };
 export const Title = ({ centered = false, copetin = '', copetinTooltip = '', description = '', descriptionTooltip = '', title, variant, withEllipsis, sx = {}, }) => {
-    return (_jsxs(Stack, { sx: Object.assign({ textAlign: centered ? 'center' : 'left', alignItems: centered ? 'center' : 'flex-start' }, sx), children: [copetin && (_jsxs(Typography, { variant: adjustedCopetin[variant], sx: Object.assign({ color: colorPalette.textColors.neutralTextLighter, alignItems: 'center', gap: 0.5 }, (withEllipsis && {
+    return (_jsxs(Stack, { sx: Object.assign({ textAlign: centered ? 'center' : 'left', alignItems: centered ? 'center' : 'flex-start' }, sx), children: [copetin && (_jsxs(Typography, { variant: adjustedCopetin[variant], sx: Object.assign({ color: colorPalette.textColors.neutralTextLighter, display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-start', gap: 1 }, (withEllipsis && {
                     overflow: 'hidden',
                     whiteSpace: 'nowrap',
                     textOverflow: 'ellipsis',
@@ -42,7 +42,7 @@ export const Title = ({ centered = false, copetin = '', copetinTooltip = '', des
                     overflow: 'hidden',
                     whiteSpace: 'nowrap',
                     textOverflow: 'ellipsis',
-                })), fontWeight: 'fontWeightSemiBold', children: title }), description && (_jsxs(Typography, { variant: adjustedDescription[variant], sx: Object.assign({ color: colorPalette.textColors.neutralTextLighter, alignItems: 'center', gap: 0.5 }, (withEllipsis && {
+                })), fontWeight: 'fontWeightSemiBold', children: title }), description && (_jsxs(Typography, { variant: adjustedDescription[variant], sx: Object.assign({ color: colorPalette.textColors.neutralTextLighter, display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-start', gap: 1 }, (withEllipsis && {
                     display: '-webkit-box',
                     WebkitBoxOrient: 'vertical',
                     WebkitLineClamp: 2,

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -81,8 +81,11 @@ export const Title = ({
           variant={adjustedCopetin[variant]}
           sx={{
             color: colorPalette.textColors.neutralTextLighter,
+            display: 'flex',
+            flexDirection: 'row',
             alignItems: 'center',
-            gap: 0.5,
+            justifyContent: 'flex-start',
+            gap: 1,
             ...(withEllipsis && {
               overflow: 'hidden',
               whiteSpace: 'nowrap',
@@ -123,8 +126,11 @@ export const Title = ({
           variant={adjustedDescription[variant]}
           sx={{
             color: colorPalette.textColors.neutralTextLighter,
+            display: 'flex',
+            flexDirection: 'row',
             alignItems: 'center',
-            gap: 0.5,
+            justifyContent: 'flex-start',
+            gap: 1,
             ...(withEllipsis && {
               display: '-webkit-box',
               WebkitBoxOrient: 'vertical',


### PR DESCRIPTION
## Summary
- Se centran los tooltips en el componente de title.

## Screenshots, GIFs or Videos
- Antes:
![imagen](https://github.com/user-attachments/assets/4abf6346-fd8b-4582-ad1e-092d7a3e3770)

- Después:
![imagen](https://github.com/user-attachments/assets/3d9a82e2-4103-49f5-8e49-2342fa0a7f82)