### PR TITLE
SelectionCard - Fix onlyoption deselect

### DIFF
--- a/lib/components/SelectionCard/FormSelectionCard.js
+++ b/lib/components/SelectionCard/FormSelectionCard.js
@@ -1,6 +1,7 @@
 import { jsx as _jsx } from "react/jsx-runtime";
 import { Controller, useFormContext } from 'react-hook-form';
 import SelectionCard from './SelectionCard';
+// this component can work either as a checkbox or a radio button, depending on the isOnlyOption prop.
 const FormSelectionCard = props => {
     const { name, rules, children, isOnlyOption = false, sx } = props;
     const { getValues, setValue } = useFormContext();
@@ -8,6 +9,7 @@ const FormSelectionCard = props => {
     const handleOnClick = (onChange, param) => {
         onChange(param);
         if (isOnlyOption) {
+            // deselect all other options
             const nameParts = name.split('.');
             const baseRoute = nameParts.slice(0, -1).join('.');
             const currentProperty = nameParts[nameParts.length - 1];
@@ -15,6 +17,8 @@ const FormSelectionCard = props => {
             Object.keys(baseObject).forEach(key => key !== currentProperty && setValue(`${baseRoute}.${key}`, false));
         }
     };
-    return (_jsx(Controller, { render: ({ field: { onChange } }) => (_jsx(SelectionCard, { onClick: param => handleOnClick(onChange, param), checked: valueInput, sx: sx, children: children })), name: name, rules: rules }));
+    // can't change value if it is the only option and it is already selected
+    const canChange = !(isOnlyOption && valueInput);
+    return (_jsx(Controller, { render: ({ field: { onChange } }) => (_jsx(SelectionCard, { onClick: param => canChange && handleOnClick(onChange, param), checked: valueInput, sx: sx, children: children })), name: name, rules: rules }));
 };
 export default FormSelectionCard;

--- a/src/components/SelectionCard/FormSelectionCard.tsx
+++ b/src/components/SelectionCard/FormSelectionCard.tsx
@@ -9,6 +9,7 @@ type FormSelectionCardProps = PropsWithChildren<{
   sx?: SelectionCardProps['sx'];
 }>;
 
+// this component can work either as a checkbox or a radio button, depending on the isOnlyOption prop.
 const FormSelectionCard: FC<FormSelectionCardProps> = props => {
   const { name, rules, children, isOnlyOption = false, sx } = props;
 
@@ -19,6 +20,7 @@ const FormSelectionCard: FC<FormSelectionCardProps> = props => {
   const handleOnClick = (onChange: Function, param: boolean) => {
     onChange(param);
     if (isOnlyOption) {
+      // deselect all other options
       const nameParts = name.split('.');
       const baseRoute = nameParts.slice(0, -1).join('.');
       const currentProperty = nameParts[nameParts.length - 1];
@@ -32,11 +34,14 @@ const FormSelectionCard: FC<FormSelectionCardProps> = props => {
     }
   };
 
+  // can't change value if it is the only option and it is already selected
+  const canChange = !(isOnlyOption && valueInput);
+
   return (
     <Controller
       render={({ field: { onChange } }) => (
         <SelectionCard
-          onClick={param => handleOnClick(onChange, param)}
+          onClick={param => canChange && handleOnClick(onChange, param)}
           checked={valueInput}
           sx={sx}
         >


### PR DESCRIPTION
## Summary

Si la SelectionCard está funcionando como un radiobutton, no se permite que se deseleccione un item