### PR TITLE
Fix | Change operation precedence

### DIFF
--- a/lib/hooks/useServerPagination.js
+++ b/lib/hooks/useServerPagination.js
@@ -51,7 +51,7 @@ const useServerPagination = (options) => {
     const setPage = useCallback((page) => setValue('pagination.page', page), [setValue]);
     const setLimit = useCallback((limit) => setValue('pagination.limit', limit), [setValue]);
     const setOrderBy = useCallback((newOrderBy) => setValue('orderBy', newOrderBy), [setValue]);
-    const setOrder = useCallback((newOrder) => setValue('order', newOrder || order === 'DESC' ? 'ASC' : 'DESC'), [setValue]);
+    const setOrder = useCallback((newOrder) => setValue('order', newOrder || (order === 'DESC' ? 'ASC' : 'DESC')), [setValue, order]);
     const setQuery = useCallback((newQuery) => setValue('query', newQuery), [setValue]);
     const TableSortingHeader = useServerTableSorting(form);
     const paginationController = (total) => (_jsx(PaginationController, { control: control, total: total, setPage: setPage, setLimit: setLimit, limitOptions: limitOptions, labelRowsPerPage: labelRowsPerPage }));

--- a/src/hooks/useServerPagination.tsx
+++ b/src/hooks/useServerPagination.tsx
@@ -112,7 +112,7 @@ const useServerPagination = (options?: ServerPaginationOptions) => {
   );
   const setOrder = useCallback(
     (newOrder?: string) =>
-      setValue('order', newOrder || order === 'DESC' ? 'ASC' : 'DESC'),
+      setValue('order', newOrder || (order === 'DESC' ? 'ASC' : 'DESC')),
     [setValue],
   );
   const setQuery = useCallback(

--- a/src/hooks/useServerPagination.tsx
+++ b/src/hooks/useServerPagination.tsx
@@ -113,7 +113,7 @@ const useServerPagination = (options?: ServerPaginationOptions) => {
   const setOrder = useCallback(
     (newOrder?: string) =>
       setValue('order', newOrder || (order === 'DESC' ? 'ASC' : 'DESC')),
-    [setValue],
+    [setValue, order],
   );
   const setQuery = useCallback(
     (newQuery: string) => setValue('query', newQuery),


### PR DESCRIPTION
## Summary
the setOrder had as new value the operation `newOrder || order === 'DESC' ? 'ASC' : 'DESC'`, which was being taken implicitly as `(newOrder || order === 'DESC') ? 'ASC' : 'DESC'`

By putting explicit parenthesis we avoid this faulty logic
It now reads: `newOrder || (order === 'DESC' ? 'ASC' : 'DESC')`

Adding `order` to the dependency array was also necessary to keep the function up-to-date

## Jira Card
NO CARD