### PR TITLE
ButtonGroup | Fix alineacion

### DIFF
--- a/lib/components/ButtonGroup/ButtonGroup.js
+++ b/lib/components/ButtonGroup/ButtonGroup.js
@@ -23,6 +23,7 @@ const ButtonGroup = ({ labels, onChange, fullWidth = false, disableUnselect = fa
                 py: 1,
                 px: 1.5,
                 flexGrow: fullWidth ? 1 : 'initial',
+                flexBasis: fullWidth ? 1 : 'auto',
                 textTransform: 'none',
             }, startIcon: selectedButton === index ? _jsx(IconCheck, { size: 16 }) : noIcon, endIcon: noIcon, children: label }, index))) }));
 };

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -61,6 +61,7 @@ const ButtonGroup = ({
             py: 1,
             px: 1.5,
             flexGrow: fullWidth ? 1 : 'initial',
+            flexBasis: fullWidth ? 1 : 'auto',
             textTransform: 'none',
           }}
           startIcon={


### PR DESCRIPTION
## Summary
Se logra que si esta fullWidth quede centrada la division y los botones de igual tamaño por pedido de Design