### PR TITLE
Avatar Group | Agregado prop custom total

### DIFF
--- a/lib/components/Avatar/Avatar.d.ts
+++ b/lib/components/Avatar/Avatar.d.ts
@@ -15,5 +15,5 @@ export declare const getColorsVariant: (color: AvatarProps['color'], palette: Pa
     backgroundColor: string;
     color: string;
 };
-export declare const Avatar: ({ size, color, withBadge, badgeProps, text, Icon, ...props }: AvatarProps) => import("react/jsx-runtime").JSX.Element;
+export declare const Avatar: ({ size, color, withBadge, badgeProps, text, Icon, sx, ...props }: AvatarProps) => import("react/jsx-runtime").JSX.Element;
 export default Avatar;

--- a/lib/components/Avatar/Avatar.js
+++ b/lib/components/Avatar/Avatar.js
@@ -91,12 +91,12 @@ const getOffset = (size, variant) => {
     return {};
 };
 export const Avatar = (_a) => {
-    var { size = 'medium', color = 'default', withBadge = false, badgeProps = { variant: 'standard', color: 'primary' }, text, Icon } = _a, props = __rest(_a, ["size", "color", "withBadge", "badgeProps", "text", "Icon"]);
+    var { size = 'medium', color = 'default', withBadge = false, badgeProps = { variant: 'standard', color: 'primary' }, text, Icon, sx } = _a, props = __rest(_a, ["size", "color", "withBadge", "badgeProps", "text", "Icon", "sx"]);
     const theme = useTheme();
     const sizeInPixels = getSizeInPixels(size);
     const colorsVariant = getColorsVariant(color, theme.palette);
     const roundedBorderRadius = theme.shape.borderRadius;
-    const avatar = (_jsxs(AvatarMui, Object.assign({ sx: Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, props.sx), colorsVariant), { height: sizeInPixels, width: sizeInPixels }), (props.variant === 'rounded' && {
+    const avatar = (_jsxs(AvatarMui, Object.assign({ sx: Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, sx), colorsVariant), { height: sizeInPixels, width: sizeInPixels }), (props.variant === 'rounded' && {
             borderRadius: roundedBorderRadius,
         })), (props.variant === 'square' && {
             borderRadius: 1,

--- a/lib/components/AvatarGroup/AvatarGroup.d.ts
+++ b/lib/components/AvatarGroup/AvatarGroup.d.ts
@@ -3,6 +3,7 @@ export declare const formatSurplus: (surplus: number) => string;
 export type Props = {
     size?: AvatarProps['size'];
     avatars: Pick<AvatarProps, 'src' | 'color' | 'alt' | 'text'>[];
+    totalAvatars?: number;
 };
-declare const AvatarGroup: ({ size, avatars }: Props) => import("react/jsx-runtime").JSX.Element;
+declare const AvatarGroup: ({ size, avatars, totalAvatars }: Props) => import("react/jsx-runtime").JSX.Element;
 export default AvatarGroup;

--- a/lib/components/AvatarGroup/AvatarGroup.js
+++ b/lib/components/AvatarGroup/AvatarGroup.js
@@ -11,7 +11,7 @@ export const formatSurplus = (surplus) => {
         ? `+${(Math.trunc(thousandFraction * 10) / 10).toString()}K`
         : `+${surplus}`;
 };
-const AvatarGroup = ({ size = 'medium', avatars }) => {
+const AvatarGroup = ({ size = 'medium', avatars, totalAvatars }) => {
     const theme = useTheme();
     const sizeInPixels = getSizeInPixels(size);
     const colorsVariant = getColorsVariant('default', theme.palette);
@@ -24,8 +24,8 @@ const AvatarGroup = ({ size = 'medium', avatars }) => {
             },
         }, slotProps: {
             additionalAvatar: {
-                sx: Object.assign({ height: sizeInPixels, width: sizeInPixels }, colorsVariant),
+                sx: Object.assign({ height: sizeInPixels, width: sizeInPixels, fontSize: (totalAvatars || avatars.length) > 99 ? 14 : 'initial' }, colorsVariant),
             },
-        }, max: MAX_AVATARS, renderSurplus: formatSurplus, children: avatars.map((a, index) => (_jsx(Avatar, Object.assign({}, a), index))) }));
+        }, max: MAX_AVATARS, renderSurplus: formatSurplus, total: totalAvatars || avatars.length, children: avatars.map((a, index) => (_jsx(Avatar, Object.assign({}, a), index))) }));
 };
 export default AvatarGroup;

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -115,6 +115,7 @@ export const Avatar = ({
   badgeProps = { variant: 'standard', color: 'primary' },
   text,
   Icon,
+  sx,
   ...props
 }: AvatarProps) => {
   const theme = useTheme();
@@ -125,7 +126,7 @@ export const Avatar = ({
   const avatar = (
     <AvatarMui
       sx={{
-        ...props.sx,
+        ...sx,
         ...colorsVariant,
         height: sizeInPixels,
         width: sizeInPixels,

--- a/src/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/src/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -27,3 +27,9 @@ export default meta;
 type Story = StoryObj<typeof AvatarGroup>;
 
 export const Default: Story = { args: {} };
+
+export const CustomTotalAvatars: Story = {
+  args: {
+    totalAvatars: 2000,
+  },
+};

--- a/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/AvatarGroup/AvatarGroup.tsx
@@ -20,9 +20,11 @@ export const formatSurplus = (surplus: number) => {
 export type Props = {
   size?: AvatarProps['size'];
   avatars: Pick<AvatarProps, 'src' | 'color' | 'alt' | 'text'>[];
+  // Use if want to show the total count without passing all the avatars info (should only fetch the first 4)
+  totalAvatars?: number;
 };
 
-const AvatarGroup = ({ size = 'medium', avatars }: Props) => {
+const AvatarGroup = ({ size = 'medium', avatars, totalAvatars }: Props) => {
   const theme = useTheme();
   const sizeInPixels = getSizeInPixels(size);
   const colorsVariant = getColorsVariant('default', theme.palette);
@@ -42,12 +44,14 @@ const AvatarGroup = ({ size = 'medium', avatars }: Props) => {
           sx: {
             height: sizeInPixels,
             width: sizeInPixels,
+            fontSize: (totalAvatars || avatars.length) > 99 ? 14 : 'initial',
             ...colorsVariant,
           },
         },
       }}
       max={MAX_AVATARS}
       renderSurplus={formatSurplus}
+      total={totalAvatars || avatars.length}
     >
       {avatars.map((a, index) => (
         <Avatar


### PR DESCRIPTION
## Summary

- Se agrega prop opcional `totalAvatars` a **AvatarGroup**. La idea es que se pueda indicar el total de avatars sin tener que pasar el array con todos ellos. Por ejemplo el caso en que el tengamos 300 usuarios: solo necesitamos buscar la información de los primeros 4 usuarios (imagenes de perfil y nombre) y pasamos el count/length bajo `totalAvatars`.
- Se hace un ajuste en la destructuración de props de **Avatar** para que no se sobrescriba el sx.

## Screenshots, GIFs or Videos


### Custom Total Avatars

![Screenshot 2024-12-03 at 6 34 56 PM](https://github.com/user-attachments/assets/dd9814b6-0d61-4981-98a1-5768ce283d51)

### SX

Antes, al aplicarle `sx={{ ml: 10 }}` sobrescribe el resto de los estilos

![Screenshot 2024-12-03 at 6 31 56 PM](https://github.com/user-attachments/assets/a8e35aff-56de-483f-8b54-e80e905bfa4e)

Despues

![Screenshot 2024-12-03 at 6 32 45 PM](https://github.com/user-attachments/assets/e4746827-999a-4ab9-99f5-2c34124534a9)
