### PR TITLE
Input Classic |  ajuste Stack de helperText

### DIFF
--- a/lib/components/Input/CustomHelperText.js
+++ b/lib/components/Input/CustomHelperText.js
@@ -21,6 +21,10 @@ const CustomHelperText = ({ helperText, hasCounter, maxLength, value, success })
             '& *': {
                 color: `${getHelperColor()} !important`,
             },
-        }, children: _jsxs(Stack, { sx: { flexDirection: 'row', alignItems: 'center', gap: 0.5 }, children: [error && _jsx(IconExclamationCircle, { size: 13 }), _jsx(Typography, { variant: "globalS", children: helperText }), showCounter && (_jsxs(Typography, { variant: "globalS", sx: { ml: 'auto' }, children: [value.length, "/", maxLength] }))] }) }));
+        }, children: _jsxs(Stack, { component: "span", sx: {
+                alignItems: 'center',
+                flexDirection: 'row',
+                gap: 0.5,
+            }, children: [error && _jsx(IconExclamationCircle, { size: 13 }), _jsx(Typography, { variant: "globalS", children: helperText }), showCounter && (_jsxs(Typography, { variant: "globalS", sx: { ml: 'auto' }, children: [value.length, "/", maxLength] }))] }) }));
 };
 export default CustomHelperText;

--- a/lib/components/Input/CustomInput.js
+++ b/lib/components/Input/CustomInput.js
@@ -15,7 +15,7 @@ const CustomInput = ({ value, onChange, placeholder, inputRef, maxLength, succes
                 borderColor: getBorderColor(theme, focused, error, success),
                 borderWidth: '1px !important',
             },
-            input: {
+            'input, textarea': {
                 '&::placeholder': {
                     color: (_c = theme.palette.textColors) === null || _c === void 0 ? void 0 : _c.neutralTextLighter,
                     opacity: 1,

--- a/src/components/Input/CustomHelperText.tsx
+++ b/src/components/Input/CustomHelperText.tsx
@@ -37,7 +37,14 @@ const CustomHelperText: FC<
         },
       }}
     >
-      <Stack sx={{ flexDirection: 'row', alignItems: 'center', gap: 0.5 }}>
+      <Stack
+        component="span"
+        sx={{
+          alignItems: 'center',
+          flexDirection: 'row',
+          gap: 0.5,
+        }}
+      >
         {error && <IconExclamationCircle size={13} />}
         <Typography variant="globalS">{helperText}</Typography>
         {showCounter && (

--- a/src/components/Input/CustomInput.tsx
+++ b/src/components/Input/CustomInput.tsx
@@ -77,7 +77,7 @@ const CustomInput: FC<CustomInputProps> = ({
           borderColor: getBorderColor(theme, focused, error, success),
           borderWidth: '1px !important',
         },
-        input: {
+        'input, textarea': {
           '&::placeholder': {
             color: theme.palette.textColors?.neutralTextLighter,
             opacity: 1,


### PR DESCRIPTION
## Summary

Al utilizar el input classic en web aparecía el siguiente error en consola

![Screenshot 2024-12-04 at 6 55 11 PM](https://github.com/user-attachments/assets/17d1de26-2f14-4772-82b7-289d19c9094a)

Esto sucede porque el componente `<FormHelperText />` utilizado en el Input Classic  es un tag `<p>`

![Screenshot 2024-12-04 at 6 55 36 PM](https://github.com/user-attachments/assets/6cb006e7-c8eb-46c8-b00e-6b9aff6b8034)

Solución: Se agregó `component="span"` al Stack utilizado bajo `<FormHelperText />` para que el anidado deje de ser inválido.

---

Aparte:
- Se cambio el color del placeholder para el input en modo multiline (textarea), ya que no tenia el mismo color al input común.

## Screenshots, GIFs or Videos


### FormHelperText child

#### Antes

![Screenshot 2024-12-04 at 7 47 18 PM](https://github.com/user-attachments/assets/79e7adc6-b853-401c-938e-636e61c027f7)

#### Despues

![image](https://github.com/user-attachments/assets/c45b420f-d8d5-4fe9-90c1-03290f8dfa81)


### Textarea Placeholder

#### Antes
<img width="1097" alt="Screenshot 2024-12-05 at 10 05 32 AM" src="https://github.com/user-attachments/assets/28f3a8c1-7728-4614-ba67-17d97a70c0a2">

#### Despues
<img width="1155" alt="Screenshot 2024-12-05 at 10 05 19 AM" src="https://github.com/user-attachments/assets/d66f80ea-b8da-4233-a231-d2716b8deaa2">


## Jira Card

Ninguna