### PR TITLE
ProgressBar | Set bar height

### DIFF
--- a/lib/components/ProgressBar/ProgressBar.d.ts
+++ b/lib/components/ProgressBar/ProgressBar.d.ts
@@ -7,7 +7,8 @@ type Props = {
     helper?: string;
     hasPercentage?: boolean;
     variant?: 'determinate' | 'indeterminate';
+    progressHeight?: number;
     sx?: StackProps['sx'];
 };
-declare const ProgressBar: ({ title, description, helper, variant, current, total, hasPercentage, sx, }: Props) => import("react/jsx-runtime").JSX.Element;
+declare const ProgressBar: ({ title, description, helper, variant, current, total, hasPercentage, progressHeight, sx, }: Props) => import("react/jsx-runtime").JSX.Element;
 export default ProgressBar;

--- a/lib/components/ProgressBar/ProgressBar.js
+++ b/lib/components/ProgressBar/ProgressBar.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Stack, LinearProgress, Typography } from '@mui/material';
 import Title from '../Title/Title';
-const ProgressBar = ({ title = '', description = '', helper = '', variant = 'indeterminate', current = 0, total = 100, hasPercentage = false, sx, }) => {
+const ProgressBar = ({ title = '', description = '', helper = '', variant = 'indeterminate', current = 0, total = 100, hasPercentage = false, progressHeight = 4, sx, }) => {
     const progress = (100 * current) / total;
     return (_jsxs(Stack, { sx: Object.assign({ gap: 0.5 }, sx), children: [(title || description) && (_jsx(Title, { variant: "S", title: title, description: description })), _jsxs(Stack, { sx: { flexDirection: 'row', alignItems: 'center' }, children: [_jsx(LinearProgress, { sx: {
                             color: theme => { var _a; return (_a = theme.palette.base) === null || _a === void 0 ? void 0 : _a.blueBrand[400]; },
@@ -9,6 +9,7 @@ const ProgressBar = ({ title = '', description = '', helper = '', variant = 'ind
                             width: '100%',
                             borderRadius: 1,
                             my: 1,
+                            height: progressHeight,
                         }, variant: variant, value: Math.min(progress, 100) }), hasPercentage && (_jsx(Typography, { variant: "globalXS", sx: {
                             color: theme => { var _a; return (_a = theme.palette.textColors) === null || _a === void 0 ? void 0 : _a.neutralTextLighter; },
                             ml: 0.5,

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -36,6 +36,13 @@ export const Determinate: Story = {
   },
 };
 
+export const DeterminateHeight: Story = {
+  args: {
+    variant: 'determinate',
+    progressHeight: 8,
+  },
+};
+
 export const Percentage: Story = {
   args: {
     hasPercentage: true,

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -9,6 +9,7 @@ type Props = {
   helper?: string;
   hasPercentage?: boolean;
   variant?: 'determinate' | 'indeterminate';
+  progressHeight?: number;
   sx?: StackProps['sx'];
 };
 
@@ -20,6 +21,7 @@ const ProgressBar = ({
   current = 0,
   total = 100,
   hasPercentage = false,
+  progressHeight = 4,
   sx,
 }: Props) => {
   const progress = (100 * current) / total;
@@ -40,6 +42,7 @@ const ProgressBar = ({
             width: '100%',
             borderRadius: 1,
             my: 1,
+            height: progressHeight,
           }}
           variant={variant}
           value={Math.min(progress, 100)}


### PR DESCRIPTION
## Summary
Default queda en 4 como estaba, pero se permite configurar ese height

## Screenshots, GIFs or Videos
<img width="835" alt="Screenshot 2024-12-11 at 3 34 32 PM" src="https://github.com/user-attachments/assets/82b3172c-d13d-48f6-b11f-83a4f5db8e0d" />
