### PR TITLE
Title | Ellipsis max lines

### DIFF
--- a/lib/components/Snackbar/Snackbar.js
+++ b/lib/components/Snackbar/Snackbar.js
@@ -82,7 +82,7 @@ export const useSnackbar = () => {
                                             borderRadius: '50%',
                                             padding: 0,
                                         },
-                                    } }), _jsxs(Stack, { children: [title && (_jsx(Typography, { color: "white", sx: Object.assign(Object.assign({}, globalXSBase), { fontSize: 16, fontWeight: 500 }), children: title })), description && (_jsx(Typography, { variant: "globalXS", fontWeight: "fontWeightRegular", color: "white", sx: Object.assign({}, globalXSBase), children: description }))] })] }), action: [
+                                    } }), _jsxs(Stack, { children: [title && (_jsx(Typography, { color: "white", sx: Object.assign(Object.assign({}, globalXSBase), { fontSize: 16, fontWeight: 500 }), children: title })), description && (_jsx(Typography, { color: "white", sx: Object.assign({}, globalXSBase), children: description }))] })] }), action: [
                             cancelAction && (_jsx(Button, { onClick: () => {
                                     cancelAction === null || cancelAction === void 0 ? void 0 : cancelAction.onClick();
                                     closeSnackbar(key);

--- a/lib/components/Snackbar/Snackbar.js
+++ b/lib/components/Snackbar/Snackbar.js
@@ -38,6 +38,13 @@ export const useSnackbar = () => {
                 };
         }
     };
+    const globalXSBase = {
+        fontFamily: 'Roboto',
+        lineHeight: '140%',
+        fontWeight: 400,
+        letterSpacing: 0.2,
+        fontSize: 14,
+    };
     const enqueueSnackbar = (props) => {
         const { title, description, hasClose = true, cancelAction, variant, } = props;
         const { Icon, color, iconColor } = getProps(variant);
@@ -75,7 +82,7 @@ export const useSnackbar = () => {
                                             borderRadius: '50%',
                                             padding: 0,
                                         },
-                                    } }), _jsxs(Stack, { children: [title && (_jsx(Typography, { variant: "globalS", fontWeight: "fontWeightSemiBold", color: "white", children: title })), description && (_jsx(Typography, { variant: "globalXS", fontWeight: "fontWeightRegular", color: "white", children: description }))] })] }), action: [
+                                    } }), _jsxs(Stack, { children: [title && (_jsx(Typography, { color: "white", sx: Object.assign(Object.assign({}, globalXSBase), { fontSize: 16, fontWeight: 500 }), children: title })), description && (_jsx(Typography, { variant: "globalXS", fontWeight: "fontWeightRegular", color: "white", sx: Object.assign({}, globalXSBase), children: description }))] })] }), action: [
                             cancelAction && (_jsx(Button, { onClick: () => {
                                     cancelAction === null || cancelAction === void 0 ? void 0 : cancelAction.onClick();
                                     closeSnackbar(key);

--- a/lib/components/Title/Title.js
+++ b/lib/components/Title/Title.js
@@ -39,9 +39,10 @@ export const Title = ({ centered = false, copetin = '', copetinTooltip = '', des
                     whiteSpace: 'nowrap',
                     textOverflow: 'ellipsis',
                 })), children: [copetin, copetinTooltip && (_jsx(Tooltip, { direction: "top", description: copetinTooltip, children: _jsx(IconInfoCircle, { size: tooltipSize[variant].copetin, color: colorPalette.textColors.neutralTextLighter }) }))] })), _jsx(Typography, { variant: `global${variant}`, sx: Object.assign({ color: colorPalette.textColors.neutralText }, (withEllipsis && {
+                    display: '-webkit-box',
+                    WebkitBoxOrient: 'vertical',
+                    WebkitLineClamp: 1,
                     overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
                 })), fontWeight: 'fontWeightSemiBold', children: title }), description && (_jsxs(Typography, { variant: adjustedDescription[variant], sx: Object.assign({ color: colorPalette.textColors.neutralTextLighter, display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-start', gap: 1 }, (withEllipsis && {
                     display: '-webkit-box',
                     WebkitBoxOrient: 'vertical',

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -74,6 +74,14 @@ export const useSnackbar = () => {
     }
   };
 
+  const globalXSBase = {
+    fontFamily: 'Roboto',
+    lineHeight: '140%',
+    fontWeight: 400,
+    letterSpacing: 0.2,
+    fontSize: 14,
+  };
+
   const enqueueSnackbar = (props: SnackbarProps) => {
     const {
       title,
@@ -143,9 +151,13 @@ export const useSnackbar = () => {
                 <Stack>
                   {title && (
                     <Typography
-                      variant="globalS"
-                      fontWeight="fontWeightSemiBold"
                       color="white"
+                      sx={{
+                        // Temporally use manual style for -> globalS
+                        ...globalXSBase,
+                        fontSize: 16,
+                        fontWeight: 500,
+                      }}
                     >
                       {title}
                     </Typography>
@@ -155,6 +167,10 @@ export const useSnackbar = () => {
                       variant="globalXS"
                       fontWeight="fontWeightRegular"
                       color="white"
+                      sx={{
+                        // Temporally use manual style for -> globalXS
+                        ...globalXSBase,
+                      }}
                     >
                       {description}
                     </Typography>

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -164,8 +164,6 @@ export const useSnackbar = () => {
                   )}
                   {description && (
                     <Typography
-                      variant="globalXS"
-                      fontWeight="fontWeightRegular"
                       color="white"
                       sx={{
                         // Temporally use manual style for -> globalXS

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -112,9 +112,10 @@ export const Title = ({
         sx={{
           color: colorPalette.textColors.neutralText,
           ...(withEllipsis && {
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: 1,
             overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
           }),
         }}
         fontWeight={'fontWeightSemiBold'}


### PR DESCRIPTION
## Summary

> **Title**

- No funcionaba bien las **ellipsis** con un titulo largo

> **Snackbar**


- Se setean los estilos de forma manual, ya que como el `SnackbarProvider` en nuestro proyecto esta por fuera del ThemeProvider, si le aplicamos estilos de Hugo no los toma. Con lo cual, temporalmente y mientras el `HugoProvider` no sea general para todo el proyecto, la mejor opcion es para **este** caso aplicar los estilos de typography manualmente.


## Screenshots, GIFs or Videos
<img height="110" alt="Screenshot 2024-12-12 at 12 11 39 PM" src="https://github.com/user-attachments/assets/5e3c6aba-0cdb-4ca6-98e5-051b59543bac" /> ➡️ <img height="110" alt="Screenshot 2024-12-12 at 12 11 13 PM" src="https://github.com/user-attachments/assets/ba376361-1a8f-45b5-9c2d-6b1aee0aa1cd" />