### PR TITLE
[No card] - Ajustes varios en componentes

### DIFF
--- a/lib/components/AvatarGroup/AvatarGroup.js
+++ b/lib/components/AvatarGroup/AvatarGroup.js
@@ -2,15 +2,7 @@ import { jsx as _jsx } from "react/jsx-runtime";
 import { AvatarGroup as AvatarGroupMui, useTheme } from '@mui/material';
 import Avatar, { getColorsVariant, getSizeInPixels, } from '../Avatar/Avatar';
 const MAX_AVATARS = 4;
-export const formatSurplus = (surplus) => {
-    const thousandFraction = surplus / 1000;
-    if (surplus > 9999 || surplus % 1000 === 0) {
-        return `+${Math.trunc(thousandFraction).toString()}K`;
-    }
-    return surplus > 999
-        ? `+${(Math.trunc(thousandFraction * 10) / 10).toString()}K`
-        : `+${surplus}`;
-};
+export const formatSurplus = (surplus) => surplus > 999 ? `+${Math.trunc(surplus / 1000)}K` : `+${surplus}`;
 const AvatarGroup = ({ size = 'medium', avatars, totalAvatars }) => {
     const theme = useTheme();
     const sizeInPixels = getSizeInPixels(size);

--- a/lib/components/Skeleton/Skeleton.js
+++ b/lib/components/Skeleton/Skeleton.js
@@ -25,6 +25,6 @@ const getBorderRadius = (variant) => {
 const Skeleton = (_a) => {
     var { isLoading = true, variant = 'rounded', // Safer default than the MUI default 'text' which is not very useful beyond single lines of text (see variant definition at https://mui.com/material-ui/react-skeleton/#variants)
     sx } = _a, skeletonProps = __rest(_a, ["isLoading", "variant", "sx"]);
-    return isLoading ? (_jsx(MuiSkeleton, Object.assign({ animation: 'wave', sx: Object.assign(Object.assign({}, sx), { borderRadius: getBorderRadius(variant) }), variant: variant }, skeletonProps))) : (_jsx(_Fragment, { children: skeletonProps === null || skeletonProps === void 0 ? void 0 : skeletonProps.children }));
+    return isLoading ? (_jsx(MuiSkeleton, Object.assign({ animation: 'wave', sx: Object.assign({ borderRadius: getBorderRadius(variant) }, sx), variant: variant }, skeletonProps))) : (_jsx(_Fragment, { children: skeletonProps === null || skeletonProps === void 0 ? void 0 : skeletonProps.children }));
 };
 export default Skeleton;

--- a/lib/components/Snackbar/Snackbar.d.ts
+++ b/lib/components/Snackbar/Snackbar.d.ts
@@ -8,6 +8,7 @@ export type SnackbarProps = {
         onClick: () => void;
     };
     onClose?: () => void;
+    autoHideDuration?: number;
 };
 export declare const useSnackbar: () => {
     enqueueSnackbar: (props: SnackbarProps) => void;

--- a/lib/components/Snackbar/Snackbar.js
+++ b/lib/components/Snackbar/Snackbar.js
@@ -5,6 +5,7 @@ import { useSnackbar as useNotistackSnackar } from 'notistack';
 import CloseIcon from '@mui/icons-material/Close';
 import { keyframes } from '@mui/system';
 import { colorPalette } from '../../theme/hugo/colors';
+const DEFAULT_HIDE_DURATION = 10000;
 export const useSnackbar = () => {
     const { enqueueSnackbar: enqueueNotistackSnackbar, closeSnackbar } = useNotistackSnackar();
     const { textColors, border, graphics } = colorPalette;
@@ -46,11 +47,11 @@ export const useSnackbar = () => {
         fontSize: 14,
     };
     const enqueueSnackbar = (props) => {
-        const { title, description, hasClose = true, cancelAction, variant, } = props;
+        const { title, description, hasClose = true, cancelAction, variant, autoHideDuration = DEFAULT_HIDE_DURATION, } = props;
         const { Icon, color, iconColor } = getProps(variant);
         const progressAnimation = keyframes `from { width: 0%; } to { width: 100%; }`;
         enqueueNotistackSnackbar('', {
-            autoHideDuration: 10000,
+            autoHideDuration,
             anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
             content: key => (_jsxs("div", { style: {
                     borderRadius: '8px',

--- a/lib/components/Snackbar/Snackbar.js
+++ b/lib/components/Snackbar/Snackbar.js
@@ -106,7 +106,7 @@ export const useSnackbar = () => {
                             backgroundColor: color,
                             '& .MuiLinearProgress-bar': {
                                 backgroundColor: iconColor,
-                                animation: `${progressAnimation} 8s linear`,
+                                animation: `${progressAnimation} ${autoHideDuration / 1000}s linear`,
                             },
                         } })] })),
         });

--- a/lib/components/Tabs/Tabs.d.ts
+++ b/lib/components/Tabs/Tabs.d.ts
@@ -1,10 +1,10 @@
 import { TabsProps } from '@mui/material';
-type Props = Pick<TabsProps, 'sx' | 'defaultValue'> & {
+type Props = Pick<TabsProps, 'sx' | 'defaultValue' | 'value'> & {
     tabs: {
         label: string;
         value: string;
     }[];
     onTabChange?: (value: string, index: number) => void;
 };
-declare const Tabs: ({ tabs, sx, onTabChange, defaultValue }: Props) => import("react/jsx-runtime").JSX.Element;
+declare const Tabs: ({ tabs, sx, onTabChange, defaultValue, value }: Props) => import("react/jsx-runtime").JSX.Element;
 export default Tabs;

--- a/lib/components/Tabs/Tabs.js
+++ b/lib/components/Tabs/Tabs.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Tabs as MuiTabs, Tab, Divider, Stack, Typography, } from '@mui/material';
 import { useState } from 'react';
-const Tabs = ({ tabs, sx, onTabChange, defaultValue }) => {
+const Tabs = ({ tabs, sx, onTabChange, defaultValue, value }) => {
     var _a;
     const [currentTab, setCurrentTab] = useState(defaultValue || ((_a = tabs === null || tabs === void 0 ? void 0 : tabs[0]) === null || _a === void 0 ? void 0 : _a.value));
     return (_jsxs(Stack, { sx: sx, children: [_jsx(MuiTabs, { sx: {
@@ -9,7 +9,7 @@ const Tabs = ({ tabs, sx, onTabChange, defaultValue }) => {
                         backgroundColor: theme => { var _a; return (_a = theme.palette.base) === null || _a === void 0 ? void 0 : _a.blueBrand[400]; },
                         borderRadius: '4px 4px 0px 0px',
                     },
-                }, value: currentTab, onChange: (e, v) => {
+                }, value: value || currentTab, onChange: (e, v) => {
                     onTabChange === null || onTabChange === void 0 ? void 0 : onTabChange(v, tabs.findIndex(tab => tab.value === v));
                     setCurrentTab(v);
                 }, children: tabs === null || tabs === void 0 ? void 0 : tabs.map(tab => (_jsx(Tab, { label: _jsx(Typography, { variant: "globalXS", fontWeight: 'fontWeightSemiBold', children: tab.label }), value: tab.value, sx: {

--- a/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/AvatarGroup/AvatarGroup.tsx
@@ -7,15 +7,8 @@ import Avatar, {
 
 const MAX_AVATARS = 4;
 
-export const formatSurplus = (surplus: number) => {
-  const thousandFraction = surplus / 1000;
-  if (surplus > 9999 || surplus % 1000 === 0) {
-    return `+${Math.trunc(thousandFraction).toString()}K`;
-  }
-  return surplus > 999
-    ? `+${(Math.trunc(thousandFraction * 10) / 10).toString()}K`
-    : `+${surplus}`;
-};
+export const formatSurplus = (surplus: number) =>
+  surplus > 999 ? `+${Math.trunc(surplus / 1000)}K` : `+${surplus}`;
 
 export type Props = {
   size?: AvatarProps['size'];

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -30,8 +30,8 @@ const Skeleton: FC<PropsWithChildren<Props>> = ({
     <MuiSkeleton
       animation={'wave'}
       sx={{
-        ...sx,
         borderRadius: getBorderRadius(variant),
+        ...sx,
       }}
       variant={variant}
       {...skeletonProps}

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -8,6 +8,11 @@ const meta: Meta<typeof SnackbarWrapper> = {
   component: SnackbarWrapper,
   title: 'Snackbar',
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      story: { height: '80px' },
+    },
+  },
   argTypes: {
     title: { control: 'text' },
     description: { control: 'text' },
@@ -112,5 +117,15 @@ export const WithLongText: Story = {
       text: 'Cancel action because it’s important',
       onClick: () => alert('Undo action triggered!'),
     },
+  },
+};
+
+export const CustomAutoHide: Story = {
+  render: args => <SnackbarTemplate {...args} />,
+  args: {
+    title: 'Will close in 5s',
+    autoHideDuration: 5000,
+    description: 'Instead of having the default value this will close sooner',
+    variant: 'success',
   },
 };

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -30,7 +30,10 @@ export type SnackbarProps = {
     onClick: () => void;
   };
   onClose?: () => void;
+  autoHideDuration?: number;
 };
+
+const DEFAULT_HIDE_DURATION = 10000;
 
 export const useSnackbar = () => {
   const { enqueueSnackbar: enqueueNotistackSnackbar, closeSnackbar } =
@@ -89,12 +92,13 @@ export const useSnackbar = () => {
       hasClose = true,
       cancelAction,
       variant,
+      autoHideDuration = DEFAULT_HIDE_DURATION,
     } = props;
     const { Icon, color, iconColor } = getProps(variant);
     const progressAnimation = keyframes`from { width: 0%; } to { width: 100%; }`;
 
     enqueueNotistackSnackbar('', {
-      autoHideDuration: 10000,
+      autoHideDuration,
       anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
       content: key => (
         <div

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -230,7 +230,7 @@ export const useSnackbar = () => {
               backgroundColor: color,
               '& .MuiLinearProgress-bar': {
                 backgroundColor: iconColor,
-                animation: `${progressAnimation} 8s linear`,
+                animation: `${progressAnimation} ${autoHideDuration / 1000}s linear`,
               },
             }}
           />

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import Tabs from './Tabs';
+import { Typography } from '@mui/material';
 
 const meta: Meta<typeof Tabs> = {
   component: Tabs,
@@ -92,5 +94,29 @@ export const SevenTabs: Story = {
       { label: 'Item 6', value: 'ITEM_6' },
       { label: 'Item 7', value: 'ITEM_7' },
     ],
+  },
+};
+
+export const ControlledValueStory: Story = {
+  render: () => {
+    const [currentTab, setCurrentTab] = useState('ITEM_1');
+
+    const handleTabChange = (value: string) => {
+      setCurrentTab(value);
+    };
+
+    return (
+      <>
+        <Typography>{`Seleccionado: ${currentTab}`}</Typography>
+        <Tabs
+          value={currentTab}
+          tabs={[
+            { label: 'Item 1', value: 'ITEM_1' },
+            { label: 'Item 2', value: 'ITEM_2' },
+          ]}
+          onTabChange={handleTabChange}
+        />
+      </>
+    );
   },
 };

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 
-type Props = Pick<TabsProps, 'sx' | 'defaultValue'> & {
+type Props = Pick<TabsProps, 'sx' | 'defaultValue' | 'value'> & {
   tabs: {
     label: string;
     value: string;
@@ -16,7 +16,7 @@ type Props = Pick<TabsProps, 'sx' | 'defaultValue'> & {
   onTabChange?: (value: string, index: number) => void;
 };
 
-const Tabs = ({ tabs, sx, onTabChange, defaultValue }: Props) => {
+const Tabs = ({ tabs, sx, onTabChange, defaultValue, value }: Props) => {
   const [currentTab, setCurrentTab] = useState(
     defaultValue || tabs?.[0]?.value,
   );
@@ -30,7 +30,7 @@ const Tabs = ({ tabs, sx, onTabChange, defaultValue }: Props) => {
             borderRadius: '4px 4px 0px 0px',
           },
         }}
-        value={currentTab}
+        value={value || currentTab}
         onChange={(e, v) => {
           onTabChange?.(
             v,


### PR DESCRIPTION
## Summary

Se realizan cambios en los componentes para SQEG-910 (no están especificados en la card)

-  Se cambia el orden de props de SX del `Skeleton` para que el borderRadius pueda ser sobrescrito de ser necesario
- Se agrega una prop de `autoHideDuration` al snackbar para especificar el tiempo de cierre del `Snackbar`
- Se agrega prop `value` al componente `Tabs` para que se pueda pasar un controlledValue en caso de necesitarlo
- En `avatarGroup` diseño eligió simplificar el contador de avatars para que muestre directamente las unidades de mil (sin mostrar, por ejemplo: '1.5k' ) ya que ocupa mucho lugar y genera ciertas inconsistencias.

## Screenshots, GIFs or Videos

#### Duracion snackbar
https://github.com/user-attachments/assets/c0a04330-3a0e-4734-9bfd-fb2755c54df6

#### Tabs
![tabs-controlled](https://github.com/user-attachments/assets/f3112fc5-dc8a-4334-bee4-69ca28ed69dc)

#### AvatarGroup
![avatarCount](https://github.com/user-attachments/assets/ce400855-c0fc-4ea3-a364-c5f671549880)


## Jira Card

Ninguna