### PR TITLE
Remove Warning | Add key prop to array elements

### DIFF
--- a/lib/components/Snackbar/Snackbar.js
+++ b/lib/components/Snackbar/Snackbar.js
@@ -93,14 +93,14 @@ export const useSnackbar = () => {
                                     color: 'white',
                                     minWidth: 'auto',
                                     maxWidth: 120,
-                                }, children: _jsx(Typography, { variant: "globalS", color: "white", fontWeight: "fontWeightRegular", sx: { textDecoration: 'underline', textTransform: 'none' }, children: cancelAction.text }) })),
+                                }, children: _jsx(Typography, { variant: "globalS", color: "white", fontWeight: "fontWeightRegular", sx: { textDecoration: 'underline', textTransform: 'none' }, children: cancelAction.text }) }, 'cancelButton')),
                             hasClose && (_jsx(IconButton, { color: "inherit", onClick: () => closeSnackbar(key), sx: {
                                     p: 0,
                                     top: 12,
                                     right: 12,
                                     fontSize: '12px',
                                     position: 'absolute',
-                                }, children: _jsx(CloseIcon, { sx: { fontSize: '16px' } }) })),
+                                }, children: _jsx(CloseIcon, { sx: { fontSize: '16px' } }) }, 'closeButton')),
                         ] }, key), _jsx(LinearProgress, { variant: "determinate", value: 100, sx: {
                             height: '6px',
                             backgroundColor: color,

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -183,6 +183,7 @@ export const useSnackbar = () => {
             action={[
               cancelAction && (
                 <Button
+                  key={'cancelButton'}
                   onClick={() => {
                     cancelAction?.onClick();
                     closeSnackbar(key);
@@ -207,6 +208,7 @@ export const useSnackbar = () => {
               ),
               hasClose && (
                 <IconButton
+                  key={'closeButton'}
                   color="inherit"
                   onClick={() => closeSnackbar(key)}
                   sx={{


### PR DESCRIPTION
## Summary
Se agregan keys a los elementos de un array para evitar que se muestre el warning de:
_Warning: Each child in a list should have a unique "key" prop._

## Screenshots, GIFs or Videos
<img width="402" alt="Screenshot 2024-12-17 at 5 02 12 PM" src="https://github.com/user-attachments/assets/7b0d00e7-553f-407b-b8a1-ecefb180176c" />
