### PR TITLE
[CustomInput] Add margin-right to startadornment

### DIFF
--- a/lib/components/Input/CustomInput.js
+++ b/lib/components/Input/CustomInput.js
@@ -19,7 +19,7 @@ const CustomInput = ({ value, onChange, placeholder, inputRef, maxLength, succes
                     : 'initial',
                 zIndex: 0,
             }, '> svg:first-of-type': {
-                marginRight: 1,
+                mr: 1,
             }, 'input, textarea': {
                 '&::placeholder': {
                     color: (_c = theme.palette.textColors) === null || _c === void 0 ? void 0 : _c.neutralTextLighter,

--- a/lib/components/Input/CustomInput.js
+++ b/lib/components/Input/CustomInput.js
@@ -18,6 +18,8 @@ const CustomInput = ({ value, onChange, placeholder, inputRef, maxLength, succes
                     ? alpha(colorPalette.border.neutralBorder, 0.5)
                     : 'initial',
                 zIndex: 0,
+            }, '> svg:first-of-type': {
+                marginRight: 1,
             }, 'input, textarea': {
                 '&::placeholder': {
                     color: (_c = theme.palette.textColors) === null || _c === void 0 ? void 0 : _c.neutralTextLighter,

--- a/src/components/Input/CustomInput.tsx
+++ b/src/components/Input/CustomInput.tsx
@@ -92,7 +92,7 @@ const CustomInput: FC<CustomInputProps> = ({
           zIndex: 0,
         },
         '> svg:first-of-type': {
-          marginRight: 1,
+          mr: 1,
         },
         'input, textarea': {
           '&::placeholder': {

--- a/src/components/Input/CustomInput.tsx
+++ b/src/components/Input/CustomInput.tsx
@@ -91,6 +91,9 @@ const CustomInput: FC<CustomInputProps> = ({
             : 'initial',
           zIndex: 0,
         },
+        '> svg:first-of-type': {
+          marginRight: 1,
+        },
         'input, textarea': {
           '&::placeholder': {
             color: theme.palette.textColors?.neutralTextLighter,

--- a/src/components/Input/InputClassic.stories.tsx
+++ b/src/components/Input/InputClassic.stories.tsx
@@ -3,7 +3,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 import InputClassic from './InputClassic';
 import FormInputClassic from './FormInputClassic';
 import { IconSearch } from '@tabler/icons-react';
-import { Stack } from '@mui/material';
 
 const meta: Meta<typeof InputClassic> = {
   component: InputClassic,
@@ -129,11 +128,7 @@ export const FormInputClassicWithStartAdorment: Story = {
             sxInput: {
               background: 'gray',
             },
-            startAdornment: (
-              <Stack sx={{ mr: 1 }}>
-                <IconSearch />
-              </Stack>
-            ),
+            startAdornment: <IconSearch />,
           }}
           name="myInput"
         />


### PR DESCRIPTION
## Summary
Le agrego un margin right por default al startAdornment para que no haya que ponerlo a mano. Doy por hecho que siempre va a ser un svg.
Intenté hacerlo con las clases de MUI pero no hay forma de que me tome las clases del adornment

## Screenshots, GIFs or Videos
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/67fda10c-f003-4dbd-9d08-225384442766" />
