### PR TITLE
delete sxInput

### DIFF
--- a/lib/components/Input/FormInputClassic.d.ts
+++ b/lib/components/Input/FormInputClassic.d.ts
@@ -3,7 +3,7 @@ import { ControllerProps } from 'react-hook-form';
 import { ComponentProps } from 'react';
 type Props = {
     name: string;
-    inputProps: Pick<ComponentProps<typeof InputClassic>, 'label' | 'placeholder' | 'sx' | 'helperText' | 'maxLength' | 'hasCounter' | 'multiline' | 'startAdornment' | 'sxInput'>;
+    inputProps: Pick<ComponentProps<typeof InputClassic>, 'label' | 'placeholder' | 'sx' | 'helperText' | 'maxLength' | 'hasCounter' | 'multiline' | 'startAdornment'>;
     rules?: ControllerProps['rules'];
 };
 declare const FormInputClassic: ({ name, inputProps, rules }: Props) => import("react/jsx-runtime").JSX.Element;

--- a/lib/components/Input/InputClassic.d.ts
+++ b/lib/components/Input/InputClassic.d.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { FormControlProps, SxProps } from '@mui/material';
+import { FormControlProps } from '@mui/material';
 import { CustomInputProps } from './CustomInput';
 export type InputProps = Pick<FormControlProps, 'sx' | 'fullWidth' | 'disabled'> & {
     label?: string;
@@ -8,7 +8,6 @@ export type InputProps = Pick<FormControlProps, 'sx' | 'fullWidth' | 'disabled'>
     error?: boolean;
     hasCounter?: boolean;
     startAdornment?: ReactNode;
-    sxInput?: SxProps;
 } & CustomInputProps;
-declare const InputClassic: ({ sx, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength, hasCounter, fullWidth, multiline, startAdornment, sxInput, disabled, }: InputProps) => import("react/jsx-runtime").JSX.Element;
+declare const InputClassic: ({ sx, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength, hasCounter, fullWidth, multiline, startAdornment, disabled, }: InputProps) => import("react/jsx-runtime").JSX.Element;
 export default InputClassic;

--- a/lib/components/Input/InputClassic.js
+++ b/lib/components/Input/InputClassic.js
@@ -3,7 +3,7 @@ import { FormControl } from '@mui/material';
 import CustomLabel from './CustomLabel';
 import CustomInput from './CustomInput';
 import CustomHelperText from './CustomHelperText';
-const InputClassic = ({ sx = {}, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength = 100, hasCounter = true, fullWidth = true, multiline, startAdornment, sxInput = null, disabled = false, }) => {
-    return (_jsxs(FormControl, { sx: sx, error: error, fullWidth: fullWidth, disabled: disabled, children: [_jsx(CustomLabel, { label: label, success: success }), _jsx(CustomInput, { value: value, onChange: onChange, placeholder: placeholder, inputRef: inputRef, maxLength: maxLength, success: success, multiline: multiline, startAdornment: startAdornment, sxInput: sxInput, disabled: disabled }), _jsx(CustomHelperText, { helperText: error ? errorText : helperText, hasCounter: hasCounter, maxLength: maxLength, value: value, success: success })] }));
+const InputClassic = ({ sx = {}, label, value, helperText, errorText, onChange, placeholder, inputRef, error, success, maxLength = 100, hasCounter = true, fullWidth = true, multiline, startAdornment, disabled = false, }) => {
+    return (_jsxs(FormControl, { sx: sx, error: error, fullWidth: fullWidth, disabled: disabled, children: [_jsx(CustomLabel, { label: label, success: success }), _jsx(CustomInput, { value: value, onChange: onChange, placeholder: placeholder, inputRef: inputRef, maxLength: maxLength, success: success, multiline: multiline, startAdornment: startAdornment, disabled: disabled }), _jsx(CustomHelperText, { helperText: error ? errorText : helperText, hasCounter: hasCounter, maxLength: maxLength, value: value, success: success })] }));
 };
 export default InputClassic;

--- a/src/components/Input/FormInputClassic.tsx
+++ b/src/components/Input/FormInputClassic.tsx
@@ -14,7 +14,6 @@ type Props = {
     | 'hasCounter'
     | 'multiline'
     | 'startAdornment'
-    | 'sxInput'
   >;
   rules?: ControllerProps['rules'];
 };

--- a/src/components/Input/InputClassic.tsx
+++ b/src/components/Input/InputClassic.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { FormControl, FormControlProps, SxProps } from '@mui/material';
+import { FormControl, FormControlProps } from '@mui/material';
 import CustomLabel from './CustomLabel';
 import CustomInput, { CustomInputProps } from './CustomInput';
 import CustomHelperText from './CustomHelperText';
@@ -14,7 +14,6 @@ export type InputProps = Pick<
   error?: boolean;
   hasCounter?: boolean;
   startAdornment?: ReactNode;
-  sxInput?: SxProps;
 } & CustomInputProps;
 
 const InputClassic = ({
@@ -33,7 +32,6 @@ const InputClassic = ({
   fullWidth = true,
   multiline,
   startAdornment,
-  sxInput = null,
   disabled = false,
 }: InputProps) => {
   return (
@@ -56,7 +54,6 @@ const InputClassic = ({
         success={success}
         multiline={multiline}
         startAdornment={startAdornment}
-        sxInput={sxInput}
         disabled={disabled}
       />
       <CustomHelperText


### PR DESCRIPTION
## Summary

Se borra la prop sxInput del `inputClassic` para evitar aplicar estilos que no fueron documentados en figma pero se mantiene dicha prop para `CustomInput` para usarlos en caso de inputs personalizados.

## Screenshots, GIFs or Videos


## Jira Card
[](https://humand.atlassian.net/browse/)