### PR TITLE
Avatar | Add priorities to the Avatar

### DIFF
--- a/lib/components/Avatar/Avatar.js
+++ b/lib/components/Avatar/Avatar.js
@@ -10,8 +10,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { Avatar as AvatarMui, useTheme, } from '@mui/material';
+import { Avatar as AvatarMui, useTheme, Typography, } from '@mui/material';
 import Badge from '../Badge/Badge';
+import { IconUser } from '@tabler/icons-react';
 export const getSizeInPixels = (size) => {
     switch (size) {
         case 'small':
@@ -90,24 +91,18 @@ const getOffset = (size, variant) => {
     }
     return {};
 };
+// shows src then text then icon
 export const Avatar = (_a) => {
-    var { size = 'medium', color = 'default', withBadge = false, badgeProps = { variant: 'standard', color: 'primary' }, text, Icon, sx } = _a, props = __rest(_a, ["size", "color", "withBadge", "badgeProps", "text", "Icon", "sx"]);
+    var { size = 'medium', color = 'default', withBadge = false, badgeProps = { variant: 'standard', color: 'primary' }, text, Icon = IconUser, sx } = _a, props = __rest(_a, ["size", "color", "withBadge", "badgeProps", "text", "Icon", "sx"]);
     const theme = useTheme();
     const sizeInPixels = getSizeInPixels(size);
     const colorsVariant = getColorsVariant(color, theme.palette);
     const roundedBorderRadius = theme.shape.borderRadius;
-    const avatar = (_jsxs(AvatarMui, Object.assign({ sx: Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, sx), colorsVariant), { height: sizeInPixels, width: sizeInPixels }), (props.variant === 'rounded' && {
+    const avatar = (_jsxs(AvatarMui, Object.assign({ sx: Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, sx), colorsVariant), { height: sizeInPixels, width: sizeInPixels }), (props.variant === 'rounded' && {
             borderRadius: roundedBorderRadius,
         })), (props.variant === 'square' && {
             borderRadius: 1,
-        })), (!props.src && {
-            // text style globalXS
-            fontFamily: 'Roboto',
-            fontSize: 14,
-            lineHeight: '140%',
-            fontWeight: 600,
-            letterSpacing: 0.2,
-        })) }, props, { children: [text, Icon && _jsx(Icon, { size: getIconSize(size) })] })));
+        })) }, props, { children: [!props.src && (_jsx(Typography, { variant: "globalXS", fontWeight: "semiBold", children: text })), !props.src && !text && Icon && _jsx(Icon, { size: getIconSize(size) })] })));
     const forcedVariant = size === 'small' || !badgeProps.badgeContent ? 'dot' : badgeProps === null || badgeProps === void 0 ? void 0 : badgeProps.variant;
     return withBadge ? (_jsx(Badge, Object.assign({}, badgeProps, { anchorOrigin: { vertical: 'bottom', horizontal: 'right' }, sx: getOffset(size, forcedVariant), 
         // On DS3 the standard variant can be used with large and medium size

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -5,9 +5,10 @@ import {
   useTheme,
   SxProps,
   Theme,
+  Typography,
 } from '@mui/material';
 import Badge, { BadgeProps } from '../Badge/Badge';
-import { TablerIcon } from '@tabler/icons-react';
+import { IconUser, TablerIcon } from '@tabler/icons-react';
 
 export type AvatarProps = Pick<
   MuiAvatarProps,
@@ -108,13 +109,14 @@ const getOffset = (
   return {};
 };
 
+// shows src then text then icon
 export const Avatar = ({
   size = 'medium',
   color = 'default',
   withBadge = false,
   badgeProps = { variant: 'standard', color: 'primary' },
   text,
-  Icon,
+  Icon = IconUser,
   sx,
   ...props
 }: AvatarProps) => {
@@ -136,19 +138,18 @@ export const Avatar = ({
         ...(props.variant === 'square' && {
           borderRadius: 1,
         }),
-        ...(!props.src && {
-          // text style globalXS
-          fontFamily: 'Roboto',
-          fontSize: 14,
-          lineHeight: '140%',
-          fontWeight: 600,
-          letterSpacing: 0.2,
-        }),
       }}
       {...props}
     >
-      {text}
-      {Icon && <Icon size={getIconSize(size)} />}
+      {!props.src && (
+        <Typography
+          variant="globalXS"
+          fontWeight="semiBold"
+        >
+          {text}
+        </Typography>
+      )}
+      {!props.src && !text && Icon && <Icon size={getIconSize(size)} />}
     </AvatarMui>
   );
   const forcedVariant =


### PR DESCRIPTION
## Summary
- Agrego prioridades al Avatar: se renderiza el `src`, si no hay el `text` y si no hay el `Icon`
- Agrego un Icon default por si no se le pasa nada (`IconUser`)

## Screenshots, GIFs or Videos
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/e8e0b323-3c29-4581-a7c1-c15f29b498f8" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/fac5cdb7-0e06-43ac-a50e-5166aacf9f81" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/b67ad84a-aa68-4c13-a049-09cf8f21a1e7" />