### PR TITLE
Drawer | Add hasBackButton prop

### DIFF
--- a/lib/components/Drawer/Drawer.d.ts
+++ b/lib/components/Drawer/Drawer.d.ts
@@ -5,6 +5,7 @@ export type DrawerProps = MuiDrawerProps & {
     title?: string;
     size?: 'medium' | 'large';
     onClose: () => void;
+    hasBackButton?: boolean;
     disableEscapeKeyDown?: boolean;
     primaryButtonProps?: LoadingButtonProps;
     secondaryButtonProps?: LoadingButtonProps;

--- a/lib/components/Drawer/Drawer.js
+++ b/lib/components/Drawer/Drawer.js
@@ -12,7 +12,7 @@ var __rest = (this && this.__rest) || function (s, e) {
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { colorPalette } from '../../theme/hugo/colors';
 import { Drawer as MuiDrawer, Stack, IconButton, Typography, } from '@mui/material';
-import { IconX } from '@tabler/icons-react';
+import { IconArrowLeft, IconX } from '@tabler/icons-react';
 import { LoadingButton } from '@mui/lab';
 const sizeStyleMap = {
     medium: {
@@ -26,7 +26,7 @@ const sizeStyleMap = {
 };
 const Drawer = (props) => {
     var _a, _b, _c;
-    const { title = '', size = 'medium', open = false, children, onClose, primaryButtonProps, secondaryButtonProps, footer, primaryContent, secondaryContent, disableEscapeKeyDown, sx, PaperProps } = props, drawerProps = __rest(props, ["title", "size", "open", "children", "onClose", "primaryButtonProps", "secondaryButtonProps", "footer", "primaryContent", "secondaryContent", "disableEscapeKeyDown", "sx", "PaperProps"]);
+    const { title = '', size = 'medium', open = false, children, onClose, primaryButtonProps, secondaryButtonProps, footer, primaryContent, secondaryContent, disableEscapeKeyDown, sx, PaperProps, hasBackButton } = props, drawerProps = __rest(props, ["title", "size", "open", "children", "onClose", "primaryButtonProps", "secondaryButtonProps", "footer", "primaryContent", "secondaryContent", "disableEscapeKeyDown", "sx", "PaperProps", "hasBackButton"]);
     const withDoubleLayout = !!primaryContent || !!secondaryContent;
     const realSize = withDoubleLayout ? 'large' : size;
     const stylesForSize = sizeStyleMap[realSize];
@@ -39,7 +39,7 @@ const Drawer = (props) => {
                     py: 2,
                     px: 3,
                     borderBottom: `1px solid ${(_a = colorPalette.border) === null || _a === void 0 ? void 0 : _a.neutralDivider}`,
-                }, children: [_jsx(Typography, { variant: "globalS", sx: { fontWeight: 'semiBold' }, children: title }), _jsx(IconButton, { onClick: onClose, children: _jsx(IconX, {}) })] }), withDoubleLayout && (_jsxs(Stack, { sx: { flexDirection: 'row', flexGrow: 1, overflow: 'hidden' }, children: [_jsx(Stack, { sx: {
+                }, children: [hasBackButton && (_jsx(IconButton, { onClick: onClose, children: _jsx(IconArrowLeft, {}) })), _jsx(Typography, { variant: "globalS", sx: { fontWeight: 'semiBold', flex: 1 }, children: title }), _jsx(IconButton, { onClick: onClose, children: _jsx(IconX, {}) })] }), withDoubleLayout && (_jsxs(Stack, { sx: { flexDirection: 'row', flexGrow: 1, overflow: 'hidden' }, children: [_jsx(Stack, { sx: {
                             p: 3,
                             overflowY: 'scroll',
                             width: '50%',

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -30,6 +30,7 @@ export const Default: Story = {
     secondaryButtonProps: {
       children: 'Secondary Action',
     },
+    hasBackButton: false,
   },
   render: props => {
     const {
@@ -38,6 +39,7 @@ export const Default: Story = {
       primaryButtonProps,
       secondaryButtonProps,
       disableEscapeKeyDown,
+      hasBackButton,
     } = props;
     const [isOpen, setIsOpen] = useState(false);
 
@@ -60,6 +62,7 @@ export const Default: Story = {
           primaryButtonProps={primaryButtonProps}
           secondaryButtonProps={secondaryButtonProps}
           disableEscapeKeyDown={disableEscapeKeyDown}
+          hasBackButton={hasBackButton}
         >
           <Typography>
             Lorem ipsum dolor sit amet consectetur. In sed ut elit nisi. Turpis

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -7,13 +7,14 @@ import {
   IconButton,
   Typography,
 } from '@mui/material';
-import { IconX } from '@tabler/icons-react';
+import { IconArrowLeft, IconX } from '@tabler/icons-react';
 import { LoadingButton, LoadingButtonProps } from '@mui/lab';
 
 export type DrawerProps = MuiDrawerProps & {
   title?: string;
   size?: 'medium' | 'large';
   onClose: () => void;
+  hasBackButton?: boolean;
   disableEscapeKeyDown?: boolean;
   primaryButtonProps?: LoadingButtonProps;
   secondaryButtonProps?: LoadingButtonProps;
@@ -48,6 +49,7 @@ const Drawer = (props: DrawerProps) => {
     disableEscapeKeyDown,
     sx,
     PaperProps,
+    hasBackButton,
     ...drawerProps
   } = props;
 
@@ -90,9 +92,14 @@ const Drawer = (props: DrawerProps) => {
           borderBottom: `1px solid ${colorPalette.border?.neutralDivider}`,
         }}
       >
+        {hasBackButton && (
+          <IconButton onClick={onClose}>
+            <IconArrowLeft />
+          </IconButton>
+        )}
         <Typography
           variant="globalS"
-          sx={{ fontWeight: 'semiBold' }}
+          sx={{ fontWeight: 'semiBold', flex: 1 }}
         >
           {title}
         </Typography>


### PR DESCRIPTION
## Summary
- Agrego una prop de `hasBackButton` al drawer para mostrar la flechita para atrás
- Al clickearla, se corre `onClose`. Si en el futuro necesitamos configurarlo podemos hacerlo, pero por lo que vi siempre es para cerrar el drawer

## Screenshots, GIFs or Videos
<img width="637" alt="image" src="https://github.com/user-attachments/assets/c0466ab2-63e7-4c76-bf6f-be702cc5ac47" />

