### PR TITLE
General | Modify theme semiBold fontWeight

### DIFF
--- a/lib/theme/hugo/typography.js
+++ b/lib/theme/hugo/typography.js
@@ -1,7 +1,7 @@
 import { colorPalette } from './colors';
 const typographyWeight = {
     fontWeightRegular: 400,
-    fontWeightSemiBold: 500,
+    fontWeightSemiBold: 600,
 };
 export const typography = Object.assign(Object.assign({}, typographyWeight), { fontFamily: 'Roboto', globalXXS: {
         fontFamily: 'Roboto',

--- a/src/theme/hugo/typography.ts
+++ b/src/theme/hugo/typography.ts
@@ -4,7 +4,7 @@ import { colorPalette } from './colors';
 
 const typographyWeight = {
   fontWeightRegular: 400,
-  fontWeightSemiBold: 500,
+  fontWeightSemiBold: 600,
 };
 
 export const typography: ThemeOptions['typography'] = {


### PR DESCRIPTION
## Summary

- Se aumenta el valor del `fontWeightSemiBold` de 500 a 600 para que sea consistente con los diseños en figma

## Screenshots, GIFs or Videos

### Antes
<img width="1215" alt="Screenshot 2025-01-13 at 12 26 07 PM" src="https://github.com/user-attachments/assets/07bf7c2d-c065-40e7-9b8e-08f1daa602c9" />
<img width="1213" alt="image" src="https://github.com/user-attachments/assets/d4b6735a-354c-4346-b8f2-0408f57b0e4f" />

### Despues
<img width="1212" alt="Screenshot 2025-01-13 at 12 25 15 PM" src="https://github.com/user-attachments/assets/624f0c2d-4ded-44fd-99a1-4fd42c84d8b8" />
<img width="1213" alt="Screenshot 2025-01-13 at 3 25 47 PM" src="https://github.com/user-attachments/assets/c18cbebf-af28-45eb-bf45-358b94f9720d" />




## Jira Card

No hay card