### PR TITLE
[] ProgressBar | Add decimal precision

### DIFF
--- a/lib/components/ProgressBar/ProgressBar.d.ts
+++ b/lib/components/ProgressBar/ProgressBar.d.ts
@@ -8,7 +8,8 @@ type Props = {
     hasPercentage?: boolean;
     variant?: 'determinate' | 'indeterminate';
     progressHeight?: number;
+    decimalPrecision?: 0 | 1 | 2;
     sx?: StackProps['sx'];
 };
-declare const ProgressBar: ({ title, description, helper, variant, current, total, hasPercentage, progressHeight, sx, }: Props) => import("react/jsx-runtime").JSX.Element;
+declare const ProgressBar: ({ title, description, helper, variant, current, total, hasPercentage, progressHeight, decimalPrecision, sx, }: Props) => import("react/jsx-runtime").JSX.Element;
 export default ProgressBar;

--- a/lib/components/ProgressBar/ProgressBar.js
+++ b/lib/components/ProgressBar/ProgressBar.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Stack, LinearProgress, Typography } from '@mui/material';
 import Title from '../Title/Title';
-const ProgressBar = ({ title = '', description = '', helper = '', variant = 'indeterminate', current = 0, total = 100, hasPercentage = false, progressHeight = 4, sx, }) => {
+const ProgressBar = ({ title = '', description = '', helper = '', variant = 'indeterminate', current = 0, total = 100, hasPercentage = false, progressHeight = 4, decimalPrecision = 0, sx, }) => {
     const progress = (100 * current) / total;
     return (_jsxs(Stack, { sx: Object.assign({ gap: 0.5 }, sx), children: [(title || description) && (_jsx(Title, { variant: "S", title: title, description: description })), _jsxs(Stack, { sx: { flexDirection: 'row', alignItems: 'center' }, children: [_jsx(LinearProgress, { sx: {
                             color: theme => { var _a; return (_a = theme.palette.base) === null || _a === void 0 ? void 0 : _a.blueBrand[400]; },
@@ -13,6 +13,6 @@ const ProgressBar = ({ title = '', description = '', helper = '', variant = 'ind
                         }, variant: variant, value: Math.min(progress, 100) }), hasPercentage && (_jsx(Typography, { variant: "globalXS", sx: {
                             color: theme => { var _a; return (_a = theme.palette.textColors) === null || _a === void 0 ? void 0 : _a.neutralTextLighter; },
                             ml: 0.5,
-                        }, children: `${Math.round(progress)}%` }))] }), helper && (_jsx(Typography, { variant: "globalXXS", sx: { color: theme => { var _a; return (_a = theme.palette.textColors) === null || _a === void 0 ? void 0 : _a.neutralTextLighter; } }, children: helper }))] }));
+                        }, children: `${Number(progress).toFixed(decimalPrecision)}%` }))] }), helper && (_jsx(Typography, { variant: "globalXXS", sx: { color: theme => { var _a; return (_a = theme.palette.textColors) === null || _a === void 0 ? void 0 : _a.neutralTextLighter; } }, children: helper }))] }));
 };
 export default ProgressBar;

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -10,6 +10,7 @@ type Props = {
   hasPercentage?: boolean;
   variant?: 'determinate' | 'indeterminate';
   progressHeight?: number;
+  decimalPrecision?: 0 | 1 | 2;
   sx?: StackProps['sx'];
 };
 
@@ -22,6 +23,7 @@ const ProgressBar = ({
   total = 100,
   hasPercentage = false,
   progressHeight = 4,
+  decimalPrecision = 0,
   sx,
 }: Props) => {
   const progress = (100 * current) / total;
@@ -55,7 +57,7 @@ const ProgressBar = ({
               ml: 0.5,
             }}
           >
-            {`${Math.round(progress)}%`}
+            {`${Number(progress).toFixed(decimalPrecision)}%`}
           </Typography>
         )}
       </Stack>


### PR DESCRIPTION
## Summary
Se agrega precision decimal que por default sigue siendo como estaba (0) pero se puede configurar 1 o 2 decimales en lo que es el label del %.