### PR TITLE
[NO-CARD] fix: Tabs color and margin

### DIFF
--- a/lib/components/Tabs/Tabs.js
+++ b/lib/components/Tabs/Tabs.js
@@ -12,7 +12,7 @@ const Tabs = ({ tabs, sx, onTabChange, defaultValue, value }) => {
                 }, value: value || currentTab, onChange: (e, v) => {
                     onTabChange === null || onTabChange === void 0 ? void 0 : onTabChange(v, tabs.findIndex(tab => tab.value === v));
                     setCurrentTab(v);
-                }, children: tabs === null || tabs === void 0 ? void 0 : tabs.map(tab => (_jsx(Tab, { label: _jsx(Typography, { variant: "globalXS", fontWeight: 'fontWeightSemiBold', children: tab.label }), value: tab.value, sx: {
+                }, children: tabs === null || tabs === void 0 ? void 0 : tabs.map(tab => (_jsx(Tab, { label: _jsx(Typography, { variant: "globalXS", fontWeight: 'fontWeightSemiBold', sx: { color: 'inherit' }, children: tab.label }), value: tab.value, sx: {
                         px: 1,
                         minWidth: 0,
                         textTransform: 'none',
@@ -20,6 +20,6 @@ const Tabs = ({ tabs, sx, onTabChange, defaultValue, value }) => {
                         '&.Mui-selected': {
                             color: theme => { var _a; return (_a = theme.palette.base) === null || _a === void 0 ? void 0 : _a.blueBrand[400]; },
                         },
-                    } }, tab.value))) }), _jsx(Divider, {})] }));
+                    } }, tab.value))) }), _jsx(Divider, { sx: { borderBottom: 0 } })] }));
 };
 export default Tabs;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -46,6 +46,7 @@ const Tabs = ({ tabs, sx, onTabChange, defaultValue, value }: Props) => {
               <Typography
                 variant="globalXS"
                 fontWeight={'fontWeightSemiBold'}
+                sx={{ color: 'inherit' }}
               >
                 {tab.label}
               </Typography>
@@ -63,7 +64,7 @@ const Tabs = ({ tabs, sx, onTabChange, defaultValue, value }: Props) => {
           />
         ))}
       </MuiTabs>
-      <Divider />
+      <Divider sx={{ borderBottom: 0 }} />
     </Stack>
   );
 };


### PR DESCRIPTION
## Summary
Se soluciona un bug donde la tab seleccionada no se mostraba en azul y el ancho del divider era de 2px en vez de 1

## Screenshots, GIFs or Videos
### Antes
![Screenshot 2025-01-15 at 09 08 30](https://github.com/user-attachments/assets/6c88ceee-26c8-4f3a-b041-d6b05541a9c6)

### Ahora
![Screenshot 2025-01-15 at 09 08 01](https://github.com/user-attachments/assets/5909e03a-f7c8-42ab-b253-de76b92bd191)