### PR TITLE
[SQSH-1973] Divider | Fix boder color 

### DIFF
--- a/lib/theme/hugo/components.js
+++ b/lib/theme/hugo/components.js
@@ -210,6 +210,7 @@ export const components = {
             root: () => ({
                 borderWidth: '1px',
                 backgroundColor: colorPalette.border.neutralDivider,
+                borderColor: colorPalette.border.neutralDivider,
                 height: 'auto',
             }),
         },

--- a/src/theme/hugo/components.ts
+++ b/src/theme/hugo/components.ts
@@ -216,6 +216,7 @@ export const components: ThemeOptions['components'] = {
       root: () => ({
         borderWidth: '1px',
         backgroundColor: colorPalette.border.neutralDivider,
+        borderColor: colorPalette.border.neutralDivider,
         height: 'auto',
       }),
     },


### PR DESCRIPTION
## Summary
Se agrega el estilo border-color al Divider para poder ver el color neutralDivider ya que, si bien el background color esta correcto, eso no es lo que se muestra en la web:

Actualmente el boder color es  `rgba(0, 0, 0, 0.12)`. Se deberia mostrar `#E9E9F4` segun el [diseño](https://www.figma.com/design/mLRasWttlTuAWuE0MeBeWD/Components?node-id=87-280&t=Hpyfc3mUhLJbGALC-0) 

## Screenshots, GIFs or Videos
Con border-color: rgba(0, 0, 0, 0.12)
![image](https://github.com/user-attachments/assets/778b43e4-8920-4908-9ffd-45883c21b8bf)

Con el boder-color: #E9E9F4
![image](https://github.com/user-attachments/assets/76d219c8-0751-46a8-aade-b4d60bb39e22)

## Jira Card
https://humand.atlassian.net/browse/SQSH-1973