### PR TITLE
Feature/add disable prop to form selection card

### DIFF
--- a/lib/components/SelectionCard/FormSelectionCard.d.ts
+++ b/lib/components/SelectionCard/FormSelectionCard.d.ts
@@ -6,6 +6,7 @@ type FormSelectionCardProps = PropsWithChildren<{
     rules?: ControllerProps['rules'];
     isOnlyOption?: boolean;
     sx?: SelectionCardProps['sx'];
+    disabled?: boolean;
 }>;
 declare const FormSelectionCard: FC<FormSelectionCardProps>;
 export default FormSelectionCard;

--- a/lib/components/SelectionCard/FormSelectionCard.js
+++ b/lib/components/SelectionCard/FormSelectionCard.js
@@ -3,7 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import SelectionCard from './SelectionCard';
 // this component can work either as a checkbox or a radio button, depending on the isOnlyOption prop.
 const FormSelectionCard = props => {
-    const { name, rules, children, isOnlyOption = false, sx } = props;
+    const { name, rules, children, isOnlyOption = false, sx, disabled } = props;
     const { getValues, setValue } = useFormContext();
     const valueInput = getValues(name);
     const handleOnClick = (onChange, param) => {
@@ -18,7 +18,7 @@ const FormSelectionCard = props => {
         }
     };
     // can't change value if it is the only option and it is already selected
-    const canChange = !(isOnlyOption && valueInput);
+    const canChange = !(isOnlyOption && valueInput) && !disabled;
     return (_jsx(Controller, { render: ({ field: { onChange } }) => (_jsx(SelectionCard, { onClick: param => canChange && handleOnClick(onChange, param), checked: valueInput, sx: sx, children: children })), name: name, rules: rules }));
 };
 export default FormSelectionCard;

--- a/src/components/SelectionCard/FormSelectionCard.tsx
+++ b/src/components/SelectionCard/FormSelectionCard.tsx
@@ -7,11 +7,12 @@ type FormSelectionCardProps = PropsWithChildren<{
   rules?: ControllerProps['rules'];
   isOnlyOption?: boolean;
   sx?: SelectionCardProps['sx'];
+  disabled?: boolean;
 }>;
 
 // this component can work either as a checkbox or a radio button, depending on the isOnlyOption prop.
 const FormSelectionCard: FC<FormSelectionCardProps> = props => {
-  const { name, rules, children, isOnlyOption = false, sx } = props;
+  const { name, rules, children, isOnlyOption = false, sx, disabled } = props;
 
   const { getValues, setValue } = useFormContext();
 
@@ -35,7 +36,7 @@ const FormSelectionCard: FC<FormSelectionCardProps> = props => {
   };
 
   // can't change value if it is the only option and it is already selected
-  const canChange = !(isOnlyOption && valueInput);
+  const canChange = !(isOnlyOption && valueInput) && !disabled;
 
   return (
     <Controller


### PR DESCRIPTION
## Summary

Al mergear este PR, agregamos una nueva propr `disabled` a la funcionalidad del componente `FormSelectionCard`, permitiendo tener casos de uso donde se requiera deshabilitar el cambio de estado interno de la card


## Screenshots, GIFs or Videos

https://github.com/user-attachments/assets/2d6dff0d-dc83-448b-9d8a-420937c8f0d9

