### PR TITLE
[Divider] Fix divider

### DIFF
--- a/lib/theme/hugo/components.js
+++ b/lib/theme/hugo/components.js
@@ -207,11 +207,9 @@ export const components = {
     },
     MuiDivider: {
         styleOverrides: {
-            root: () => ({
-                borderWidth: '1px',
-                backgroundColor: colorPalette.border.neutralDivider,
+            root: ({ ownerState: { orientation } }) => ({
                 borderColor: colorPalette.border.neutralDivider,
-                height: 'auto',
+                height: orientation === 'vertical' ? 'auto' : 0,
             }),
         },
     },

--- a/lib/theme/hugo/components.js
+++ b/lib/theme/hugo/components.js
@@ -209,6 +209,7 @@ export const components = {
         styleOverrides: {
             root: ({ ownerState: { orientation } }) => ({
                 backgroundColor: colorPalette.border.neutralDivider,
+                // Divider's color is provided by its single border
                 borderColor: colorPalette.border.neutralDivider,
                 height: orientation === 'vertical' ? 'auto' : 0,
             }),

--- a/lib/theme/hugo/components.js
+++ b/lib/theme/hugo/components.js
@@ -208,6 +208,7 @@ export const components = {
     MuiDivider: {
         styleOverrides: {
             root: ({ ownerState: { orientation } }) => ({
+                backgroundColor: colorPalette.border.neutralDivider,
                 borderColor: colorPalette.border.neutralDivider,
                 height: orientation === 'vertical' ? 'auto' : 0,
             }),

--- a/src/theme/hugo/components.ts
+++ b/src/theme/hugo/components.ts
@@ -214,6 +214,7 @@ export const components: ThemeOptions['components'] = {
   MuiDivider: {
     styleOverrides: {
       root: ({ ownerState: { orientation } }) => ({
+        backgroundColor: colorPalette.border.neutralDivider,
         borderColor: colorPalette.border.neutralDivider,
         height: orientation === 'vertical' ? 'auto' : 0,
       }),

--- a/src/theme/hugo/components.ts
+++ b/src/theme/hugo/components.ts
@@ -213,11 +213,9 @@ export const components: ThemeOptions['components'] = {
   },
   MuiDivider: {
     styleOverrides: {
-      root: () => ({
-        borderWidth: '1px',
-        backgroundColor: colorPalette.border.neutralDivider,
+      root: ({ ownerState: { orientation } }) => ({
         borderColor: colorPalette.border.neutralDivider,
-        height: 'auto',
+        height: orientation === 'vertical' ? 'auto' : 0,
       }),
     },
   },

--- a/src/theme/hugo/components.ts
+++ b/src/theme/hugo/components.ts
@@ -214,7 +214,8 @@ export const components: ThemeOptions['components'] = {
   MuiDivider: {
     styleOverrides: {
       root: ({ ownerState: { orientation } }) => ({
-        backgroundColor: colorPalette.border.neutralDivider,
+        backgroundColor: colorPalette.border.neutralDivider, // this is not used unless you style the Divider with extra width/height
+        // Divider's color is provided by its single border
         borderColor: colorPalette.border.neutralDivider,
         height: orientation === 'vertical' ? 'auto' : 0,
       }),


### PR DESCRIPTION
## Summary
Dejo la configuración "default" de material-ui para el divider, que coincide con nuestro figma. Lo que le da color al divider es su unico border.
Como el elemento en sí tiene altura/width 0, el `backgroundColor` no debería influir en nada. Igual lo mantengo por si en alguna pantalla quieren customizarlo para hacerlo más grueso.

Antes
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/0e2fb985-07fa-48ba-af8d-41ac7f1f826c" />
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/3988e4cf-ef01-4951-b946-b667848eb1dd" />


Despues
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/859985e1-eb0b-451a-a3cd-133ad806a0d1" />
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/a2d4a6a4-3443-421a-ae96-011e7c68a5ce" />
