### PR TITLE
Fix search with less than 3 characters

### DIFF
--- a/lib/hooks/useHuPagination.d.ts
+++ b/lib/hooks/useHuPagination.d.ts
@@ -1,10 +1,10 @@
 import { FC } from 'react';
 import { FormSearchProps } from '../components/Input/FormSearch';
 import { FormPaginationProps } from '../components/Input/FormPagination';
-export type SearchControllerProps = Omit<FormSearchProps, 'name' | 'inputProps'> & {
+export type SearchControllerProps = Omit<FormSearchProps, 'name'> & {
     inputProps?: Omit<FormSearchProps['inputProps'], 'onChange'>;
 };
-export type PaginationControllerProps = Omit<FormPaginationProps, 'name' | 'inputProps'> & {
+export type PaginationControllerProps = Omit<FormPaginationProps, 'name'> & {
     inputProps?: Omit<FormPaginationProps['inputProps'], 'onChangeLimit' | 'onChangePage' | 'limitOptions'>;
 };
 export type PaginationParams = {

--- a/lib/hooks/useHuPagination.js
+++ b/lib/hooks/useHuPagination.js
@@ -60,10 +60,6 @@ export const useHuPagination = (options) => {
         setParams({ search, pagination: { page: FIRST_PAGE, limit: newLimit } });
     };
     const handleChangeSearch = (newSearch) => {
-        if (newSearch.length < SEARCH_MIN_LENGTH) {
-            setUrlParams();
-            return;
-        }
         const { pagination: { limit }, } = getValues('params');
         setParams({ search: newSearch, pagination: { page: FIRST_PAGE, limit } });
     };

--- a/src/hooks/useHuPagination.tsx
+++ b/src/hooks/useHuPagination.tsx
@@ -10,17 +10,11 @@ import { formatSearchParams } from '../utils/pagination';
 const SEARCH_MIN_LENGTH = 3;
 const FIRST_PAGE = 1;
 
-export type SearchControllerProps = Omit<
-  FormSearchProps,
-  'name' | 'inputProps'
-> & {
+export type SearchControllerProps = Omit<FormSearchProps, 'name'> & {
   inputProps?: Omit<FormSearchProps['inputProps'], 'onChange'>;
 };
 
-export type PaginationControllerProps = Omit<
-  FormPaginationProps,
-  'name' | 'inputProps'
-> & {
+export type PaginationControllerProps = Omit<FormPaginationProps, 'name'> & {
   inputProps?: Omit<
     FormPaginationProps['inputProps'],
     'onChangeLimit' | 'onChangePage' | 'limitOptions'
@@ -114,11 +108,6 @@ export const useHuPagination = (options?: UseHuPaginationOptions) => {
   };
 
   const handleChangeSearch = (newSearch: string) => {
-    if (newSearch.length < SEARCH_MIN_LENGTH) {
-      setUrlParams();
-      return;
-    }
-
     const {
       pagination: { limit },
     } = getValues('params');


### PR DESCRIPTION
## Summary
- Cuando el search tenía menos de 3 caracteres se setteaban los urlParams en vacío y eso hacía que el valor de search pase a ser vacío. Esto generaba que cuando el usuario tenía 3 caracteres y borraba una, se le borraba todo el input.

## Jira Card
[Libraries | Ajustes QA Formulario ](https://humand.atlassian.net/browse/SQDP-1509)