### PR TITLE
[SQRC-129] Sidesheet | useSidesheet based on Drawer

### DIFF
--- a/lib/components/Drawer/Drawer.js
+++ b/lib/components/Drawer/Drawer.js
@@ -50,7 +50,7 @@ const Drawer = (props) => {
                             bgcolor: colorPalette.hugoBackground.neutralBgSecondary,
                         }, children: secondaryContent })] })), !withDoubleLayout && (_jsx(Stack, { sx: {
                     p: 3,
-                    overflowY: 'scroll',
+                    overflowY: 'auto',
                     flexGrow: 1,
                 }, children: children })), hasExtraFooter && (_jsx(Stack, { sx: {
                     px: 3,

--- a/lib/hooks/useSidesheet.d.ts
+++ b/lib/hooks/useSidesheet.d.ts
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { DrawerProps } from '../components/Drawer/Drawer';
 declare function useSidesheet<T>(DrawerContentComponent: FC<T>, drawerProps?: Partial<DrawerProps> & {
-    whenClose: () => void;
+    whenClose?: () => void;
 }, extraProps?: Partial<T>): {
     containerStyles: {
         display: string;

--- a/lib/hooks/useSidesheet.d.ts
+++ b/lib/hooks/useSidesheet.d.ts
@@ -1,0 +1,15 @@
+import { FC } from 'react';
+import { DrawerProps } from '../components/Drawer/Drawer';
+declare function useSidesheet<T>(DrawerContentComponent: FC<T>, drawerProps?: Partial<DrawerProps> & {
+    whenClose: () => void;
+}, extraProps?: Partial<T>): {
+    containerStyles: {
+        display: string;
+        height: string;
+        marginRight: string;
+    };
+    drawer: import("react/jsx-runtime").JSX.Element;
+    closeDrawer: () => void;
+    showDrawer: (props?: Partial<T>) => void;
+};
+export { useSidesheet };

--- a/lib/hooks/useSidesheet.js
+++ b/lib/hooks/useSidesheet.js
@@ -1,0 +1,36 @@
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
+import { useState, useMemo } from 'react';
+import Drawer from '../components/Drawer/Drawer';
+function useSidesheet(DrawerContentComponent, drawerProps, extraProps) {
+    const [open, setOpen] = useState(false);
+    const closeDrawer = () => {
+        var _a;
+        setOpen(false);
+        (_a = drawerProps === null || drawerProps === void 0 ? void 0 : drawerProps.whenClose) === null || _a === void 0 ? void 0 : _a.call(drawerProps);
+    };
+    const [drawerContentProps, setDrawerContentProps] = useState();
+    const drawerWidth = 340;
+    const containerStyles = useMemo(() => ({
+        display: 'flex',
+        height: '100%',
+        marginRight: open ? `${drawerWidth}px` : '0px',
+    }), [open, drawerWidth]);
+    return {
+        containerStyles,
+        drawer: (_jsxs(_Fragment, { children: [open && (_jsx("div", { onClick: closeDrawer, style: {
+                        top: 0,
+                        left: 0,
+                        zIndex: 999,
+                        width: '100vw',
+                        height: '100vh',
+                        position: 'fixed',
+                        background: 'transparent',
+                    } })), _jsx(Drawer, Object.assign({ open: open, variant: "persistent", onClose: closeDrawer, PaperProps: { sx: { width: drawerWidth, mt: 8 } } }, drawerProps, { children: _jsx(DrawerContentComponent, Object.assign({ onClose: closeDrawer }, drawerContentProps, extraProps)) }))] })),
+        closeDrawer,
+        showDrawer: (props = {}) => {
+            setDrawerContentProps(props);
+            setOpen(true);
+        },
+    };
+}
+export { useSidesheet };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -24,6 +24,7 @@ export { useServerPagination, TableSortingHeaderProps, } from './hooks/useServer
 export { useClientPagination } from './hooks/useClientPagination';
 export { useModal } from './hooks/useModal';
 export { useDrawer } from './hooks/useDrawer';
+export { useSidesheet } from './hooks/useSidesheet';
 export { createHuGoTheme } from './theme/hugo';
 export declare const PeopleExperience: {
     DisplayGroup: <TData extends {

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ export { useServerPagination, } from './hooks/useServerPagination';
 export { useClientPagination } from './hooks/useClientPagination';
 export { useModal } from './hooks/useModal';
 export { useDrawer } from './hooks/useDrawer';
+export { useSidesheet } from './hooks/useSidesheet';
 export { createHuGoTheme } from './theme/hugo';
 export const PeopleExperience = {
     DisplayGroup,

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Drawer from './Drawer';
 import { Typography, Stack, Button } from '@mui/material';
 import { useSidesheet } from '../../hooks/useSidesheet';
+import CardContainer from '../CardContainer/CardContainer';
 
 const meta: Meta<typeof Drawer> = {
   component: Drawer,
@@ -128,7 +129,15 @@ export const Sidesheet: Story = {
     };
 
     const { showDrawer, drawer, containerStyles } = useSidesheet(
-      () => <Typography>{title}</Typography>,
+      () => (
+        <Stack>
+          <Typography>{title}</Typography>
+          <CardContainer
+            title="lalallaa"
+            sx={{ width: 2 }}
+          />
+        </Stack>
+      ),
       {
         title: 'Agregar componente',
         whenClose: handleClose,

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import Drawer from './Drawer';
 import { Typography, Stack, Button } from '@mui/material';
-import { useSidesheet } from '../../hooks/useSidesheet';
-import CardContainer from '../CardContainer/CardContainer';
 
 const meta: Meta<typeof Drawer> = {
   component: Drawer,
@@ -112,53 +110,6 @@ export const Default: Story = {
           </Typography>
         </Drawer>
       </div>
-    );
-  },
-};
-
-export const Sidesheet: Story = {
-  args: {
-    title: 'Soy un título del Drawer',
-  },
-  render: props => {
-    const { title } = props;
-    const [color, setColor] = useState('green');
-
-    const handleClose = () => {
-      setColor('green');
-    };
-
-    const { showDrawer, drawer, containerStyles } = useSidesheet(
-      () => (
-        <Stack>
-          <Typography>{title}</Typography>
-          <CardContainer
-            title="lalallaa"
-            sx={{ width: 2 }}
-          />
-        </Stack>
-      ),
-      {
-        title: 'Agregar componente',
-        whenClose: handleClose,
-      },
-    );
-
-    return (
-      <Stack sx={containerStyles}>
-        {drawer}
-        <Button
-          variant="primary"
-          size="large"
-          sx={{ width: 'fit-content', backgroundColor: color }}
-          onClick={() => {
-            setColor('blue');
-            showDrawer();
-          }}
-        >
-          Open dialog
-        </Button>
-      </Stack>
     );
   },
 };

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import Drawer from './Drawer';
 import { Typography, Stack, Button } from '@mui/material';
+import { useSidesheet } from '../../hooks/useSidesheet';
 
 const meta: Meta<typeof Drawer> = {
   component: Drawer,
@@ -110,6 +111,46 @@ export const Default: Story = {
           </Typography>
         </Drawer>
       </div>
+    );
+  },
+};
+
+export const Sidesheet: Story = {
+  args: {
+    title: 'Soy un título del Drawer',
+  },
+  render: props => {
+    const { title } = props;
+    const [color, setColor] = useState('green');
+
+    const handleClose = () => {
+      setColor('green');
+    };
+
+    const { showDrawer, drawer, containerStyles } = useSidesheet(
+      () => <Typography>{title}</Typography>,
+      {
+        title: 'Agregar componente',
+        whenClose: handleClose,
+      },
+      {},
+    );
+
+    return (
+      <Stack sx={containerStyles}>
+        {drawer}
+        <Button
+          variant="primary"
+          size="large"
+          sx={{ width: 'fit-content', backgroundColor: color }}
+          onClick={() => {
+            setColor('blue');
+            showDrawer();
+          }}
+        >
+          Open dialog
+        </Button>
+      </Stack>
     );
   },
 };

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -133,7 +133,6 @@ export const Sidesheet: Story = {
         title: 'Agregar componente',
         whenClose: handleClose,
       },
-      {},
     );
 
     return (

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -134,7 +134,7 @@ const Drawer = (props: DrawerProps) => {
         <Stack
           sx={{
             p: 3,
-            overflowY: 'scroll',
+            overflowY: 'auto',
             flexGrow: 1,
           }}
         >

--- a/src/hooks/useSidesheet.tsx
+++ b/src/hooks/useSidesheet.tsx
@@ -3,7 +3,7 @@ import Drawer, { DrawerProps } from '../components/Drawer/Drawer';
 
 function useSidesheet<T>(
   DrawerContentComponent: FC<T>,
-  drawerProps?: Partial<DrawerProps> & { whenClose: () => void },
+  drawerProps?: Partial<DrawerProps> & { whenClose?: () => void },
   extraProps?: Partial<T>,
 ) {
   const [open, setOpen] = useState(false);

--- a/src/hooks/useSidesheet.tsx
+++ b/src/hooks/useSidesheet.tsx
@@ -1,0 +1,67 @@
+import { useState, useMemo, FC } from 'react';
+import Drawer, { DrawerProps } from '../components/Drawer/Drawer';
+
+function useSidesheet<T>(
+  DrawerContentComponent: FC<T>,
+  drawerProps?: Partial<DrawerProps> & { whenClose: () => void },
+  extraProps?: Partial<T>,
+) {
+  const [open, setOpen] = useState(false);
+  const closeDrawer = () => {
+    setOpen(false);
+    drawerProps?.whenClose?.();
+  };
+
+  const [drawerContentProps, setDrawerContentProps] = useState<Partial<T>>();
+  const drawerWidth = 340;
+  const containerStyles = useMemo(
+    () => ({
+      display: 'flex',
+      height: '100%',
+      marginRight: open ? `${drawerWidth}px` : '0px',
+    }),
+    [open, drawerWidth],
+  );
+
+  return {
+    containerStyles,
+    drawer: (
+      <>
+        {open && (
+          <div
+            onClick={closeDrawer}
+            style={{
+              top: 0,
+              left: 0,
+              zIndex: 999,
+              width: '100vw',
+              height: '100vh',
+              position: 'fixed',
+              background: 'transparent',
+            }}
+          />
+        )}
+        <Drawer
+          open={open}
+          variant="persistent"
+          onClose={closeDrawer}
+          PaperProps={{ sx: { width: drawerWidth, mt: 8 } }}
+          {...drawerProps}
+        >
+          <DrawerContentComponent
+            onClose={closeDrawer}
+            {...(drawerContentProps as T)}
+            {...extraProps}
+          />
+        </Drawer>
+      </>
+    ),
+    closeDrawer,
+    showDrawer: (props: Partial<T> = {}) => {
+      setDrawerContentProps(props);
+      setOpen(true);
+    },
+  };
+}
+
+export { useSidesheet };

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export {
 export { useClientPagination } from './hooks/useClientPagination';
 export { useModal } from './hooks/useModal';
 export { useDrawer } from './hooks/useDrawer';
+export { useSidesheet } from './hooks/useSidesheet';
 export { createHuGoTheme } from './theme/hugo';
 export const PeopleExperience = {
   DisplayGroup,


### PR DESCRIPTION
## Summary
Hook implementado para necesidad especifica
- Analogo a `useDrawer`
- Con persistencia y export de style para que el container sea desplazado en la apertura del sidesheet

- Fix en Drawer para que no se muestre siempre la barra lateral del scroll:  ✅  |  ❌ 
<img width="300" alt="Screenshot 2025-01-29 at 11 42 58 AM" src="https://github.com/user-attachments/assets/f03e9c66-f48a-4b5f-9202-8783ab1963ba" />
<img width="300" alt="Screenshot 2025-01-29 at 11 44 02 AM" src="https://github.com/user-attachments/assets/86a63c2c-91c9-4663-a67a-4c83a111f4a6" />


## Jira Card
[SQRC-129](https://humand.atlassian.net/browse/SQRC-129)

[SQRC-129]: https://humand.atlassian.net/browse/SQRC-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ