### PR TITLE
Edit post + MenuList

### DIFF
--- a/lib/components/List/ListItem.d.ts
+++ b/lib/components/List/ListItem.d.ts
@@ -12,6 +12,7 @@ export type ListItemProps = Omit<ContainerProps, 'children' | 'sx'> & Pick<Stack
     action?: Pick<MuiIconButtonProps, 'id' | 'color' | 'disabled' | 'onClick' | 'aria-label'> & {
         Icon: TablerIcon;
     };
+    actionMenuList?: ReactNode;
     sideContent?: ReactNode;
 };
 export declare const ListItem: FC<ListItemProps>;

--- a/lib/components/List/ListItem.d.ts
+++ b/lib/components/List/ListItem.d.ts
@@ -3,7 +3,7 @@ import { StackProps, ListItemProps as MuiLisItemProps, IconButtonProps as MuiIco
 import { TitleProps } from '../Title/Title';
 import { AvatarProps } from '../Avatar/Avatar';
 import { TablerIcon } from '@tabler/icons-react';
-type ContainerProps = Pick<MuiLisItemProps, 'children' | 'divider' | 'sx'>;
+type ContainerProps = Pick<MuiLisItemProps, 'children' | 'divider' | 'sx' | 'component'>;
 export type ListItemProps = Omit<ContainerProps, 'children' | 'sx'> & Pick<StackProps, 'id' | 'sx'> & {
     loading?: boolean;
     onClick?: (event: MouseEvent<HTMLDivElement>) => void;

--- a/lib/components/List/ListItem.js
+++ b/lib/components/List/ListItem.js
@@ -14,7 +14,7 @@ import { Stack, Divider, ListItem as MuiListItem, ListItemButton as MuiListItemB
 import ListItemSkeleton from './ListItemSkeleton';
 import { Title } from '../Title/Title';
 import { Avatar } from '../Avatar/Avatar';
-export const ListItem = ({ id, sx, loading = false, onClick, text, avatar, action, divider, sideContent, }) => {
+export const ListItem = ({ id, sx, loading = false, onClick, text, avatar, action, actionMenuList, divider, sideContent, }) => {
     const Container = onClick
         ? (props) => (_jsx(MuiListItemButton, Object.assign({}, props, { onClick: onClick })))
         : (props) => _jsx(MuiListItem, Object.assign({}, props));
@@ -44,6 +44,6 @@ export const ListItem = ({ id, sx, loading = false, onClick, text, avatar, actio
                                         width: 'inherit',
                                         height: 'inherit',
                                     },
-                                } }, actionRest, { onClick: handleClick(action.onClick), children: ActionIcon && _jsx(ActionIcon, { size: 24 }) })))] })] })), divider && _jsx(Divider, { variant: "middle" })] }));
+                                } }, actionRest, { onClick: handleClick(action.onClick), children: ActionIcon && _jsx(ActionIcon, { size: 24 }) }))), actionMenuList] })] })), divider && _jsx(Divider, { variant: "middle" })] }));
 };
 export default ListItem;

--- a/lib/components/List/ListItem.js
+++ b/lib/components/List/ListItem.js
@@ -14,7 +14,7 @@ import { Stack, Divider, ListItem as MuiListItem, ListItemButton as MuiListItemB
 import ListItemSkeleton from './ListItemSkeleton';
 import { Title } from '../Title/Title';
 import { Avatar } from '../Avatar/Avatar';
-export const ListItem = ({ id, sx, loading = false, onClick, text, avatar, action, actionMenuList, divider, sideContent, }) => {
+export const ListItem = ({ id, sx, loading = false, onClick, text, avatar, action, actionMenuList, divider, sideContent, component, }) => {
     const Container = onClick
         ? (props) => (_jsx(MuiListItemButton, Object.assign({}, props, { onClick: onClick })))
         : (props) => _jsx(MuiListItem, Object.assign({}, props));
@@ -23,7 +23,7 @@ export const ListItem = ({ id, sx, loading = false, onClick, text, avatar, actio
         callback && callback(event);
     };
     const _a = action || {}, { Icon: ActionIcon } = _a, actionRest = __rest(_a, ["Icon"]);
-    return (_jsxs(Stack, { id: id, sx: Object.assign({ minHeight: '40px', flexDirection: 'column' }, sx), children: [loading && _jsx(ListItemSkeleton, {}), !loading && (_jsxs(Container, { sx: {
+    return (_jsxs(Stack, { id: id, sx: Object.assign({ minHeight: '40px', flexDirection: 'column' }, sx), children: [loading && _jsx(ListItemSkeleton, {}), !loading && (_jsxs(Container, { component: component, sx: {
                     p: 2,
                     gap: 0.5,
                     flexDirection: 'row',

--- a/lib/components/Menu/MenuList.d.ts
+++ b/lib/components/Menu/MenuList.d.ts
@@ -10,4 +10,4 @@ type Props = {
     }[];
 };
 export declare const MenuList: FC<Props>;
-export {};
+export default MenuList;

--- a/lib/components/Menu/MenuList.d.ts
+++ b/lib/components/Menu/MenuList.d.ts
@@ -7,6 +7,7 @@ type Props = {
         title: string;
         description?: string;
         onClick: () => void;
+        disabled?: boolean;
     }[];
 };
 export declare const MenuList: FC<Props>;

--- a/lib/components/Menu/MenuList.d.ts
+++ b/lib/components/Menu/MenuList.d.ts
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { IconDotsVertical } from '@tabler/icons-react';
+type Props = {
+    Icon?: typeof IconDotsVertical;
+    options: {
+        Icon?: any;
+        title: string;
+        description?: string;
+        onClick: () => void;
+    }[];
+};
+export declare const MenuList: FC<Props>;
+export {};

--- a/lib/components/Menu/MenuList.d.ts
+++ b/lib/components/Menu/MenuList.d.ts
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { IconDotsVertical } from '@tabler/icons-react';
 type Props = {
     Icon?: typeof IconDotsVertical;
@@ -9,6 +9,7 @@ type Props = {
         onClick: () => void;
         disabled?: boolean;
     }[];
+    customButton?: ReactNode;
 };
 export declare const MenuList: FC<Props>;
 export default MenuList;

--- a/lib/components/Menu/MenuList.d.ts
+++ b/lib/components/Menu/MenuList.d.ts
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FC, ReactElement } from 'react';
 import { IconDotsVertical } from '@tabler/icons-react';
 type Props = {
     Icon?: typeof IconDotsVertical;
@@ -9,7 +9,8 @@ type Props = {
         onClick: () => void;
         disabled?: boolean;
     }[];
-    customButton?: ReactNode;
+    customButton?: ReactElement;
+    disableMenu?: boolean;
 };
 export declare const MenuList: FC<Props>;
 export default MenuList;

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -1,16 +1,16 @@
 import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
 import { useRef, useState } from 'react';
-import { IconButton } from '@mui/material';
+import { IconButton, Stack } from '@mui/material';
 import { IconDotsVertical } from '@tabler/icons-react';
 import Menu from './Menu';
 import MenuItem from './MenuItem';
 import ListItem from '../List/ListItem';
-export const MenuList = ({ Icon = IconDotsVertical, options }) => {
+export const MenuList = ({ Icon = IconDotsVertical, options, customButton, }) => {
     const [openMenu, setOpenMenu] = useState(false);
     const anchorRef = useRef(null);
     const handleMenuOpen = () => setOpenMenu(true);
     const handleMenuClose = () => setOpenMenu(false);
-    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { ul: { py: 0 }, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
+    return (_jsxs(_Fragment, { children: [!!customButton && (_jsx(Stack, { ref: anchorRef, onClick: handleMenuOpen, children: customButton })), !customButton && (_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) })), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { ul: { py: 0 }, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
                         option.onClick();
                         handleMenuClose();
                     }, disabled: option.disabled, children: _jsx(ListItem, { component: "div", text: {

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -1,16 +1,20 @@
 import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
-import { useRef, useState } from 'react';
-import { IconButton, Stack } from '@mui/material';
+import { cloneElement, useRef, useState } from 'react';
+import { IconButton } from '@mui/material';
 import { IconDotsVertical } from '@tabler/icons-react';
 import Menu from './Menu';
 import MenuItem from './MenuItem';
 import ListItem from '../List/ListItem';
-export const MenuList = ({ Icon = IconDotsVertical, options, customButton, }) => {
+export const MenuList = ({ Icon = IconDotsVertical, options, customButton, disableMenu, }) => {
     const [openMenu, setOpenMenu] = useState(false);
     const anchorRef = useRef(null);
     const handleMenuOpen = () => setOpenMenu(true);
     const handleMenuClose = () => setOpenMenu(false);
-    return (_jsxs(_Fragment, { children: [!!customButton && (_jsx(Stack, { ref: anchorRef, onClick: handleMenuOpen, children: customButton })), !customButton && (_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) })), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { ul: { py: 0 }, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
+    return (_jsxs(_Fragment, { children: [!!customButton &&
+                cloneElement(customButton, {
+                    ref: anchorRef,
+                    onClick: disableMenu ? undefined : handleMenuOpen,
+                }), !customButton && (_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) })), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { ul: { py: 0 }, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
                         option.onClick();
                         handleMenuClose();
                     }, disabled: option.disabled, children: _jsx(ListItem, { component: "div", text: {

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -18,3 +18,4 @@ export const MenuList = ({ Icon = IconDotsVertical, options }) => {
                             description: option === null || option === void 0 ? void 0 : option.description,
                         }, sx: { '.MuiListItem-root': { p: 0 }, justifyContent: 'center' }, avatar: option.Icon && { Icon: option.Icon } }) }, option.title))) })] }));
 };
+export default MenuList;

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -13,7 +13,7 @@ export const MenuList = ({ Icon = IconDotsVertical, options }) => {
     return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { py: 0, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
                         option.onClick();
                         handleMenuClose();
-                    }, children: _jsx(ListItem, { component: "div", text: {
+                    }, disabled: option.disabled, children: _jsx(ListItem, { component: "div", text: {
                             title: option.title,
                             description: option === null || option === void 0 ? void 0 : option.description,
                         }, sx: { '.MuiListItem-root': { p: 0 }, justifyContent: 'center' }, avatar: option.Icon && { Icon: option.Icon } }) }, option.title))) })] }));

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -10,7 +10,7 @@ export const MenuList = ({ Icon = IconDotsVertical, options }) => {
     const anchorRef = useRef(null);
     const handleMenuOpen = () => setOpenMenu(true);
     const handleMenuClose = () => setOpenMenu(false);
-    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { py: 0 }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
+    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { py: 0, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
                         option.onClick();
                         handleMenuClose();
                     }, children: _jsx(ListItem, { component: "div", text: {

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -10,11 +10,11 @@ export const MenuList = ({ Icon = IconDotsVertical, options }) => {
     const anchorRef = useRef(null);
     const handleMenuOpen = () => setOpenMenu(true);
     const handleMenuClose = () => setOpenMenu(false);
-    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { '.MuiListItem-root': { p: 0 } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
+    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { py: 0 }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
                         option.onClick();
                         handleMenuClose();
-                    }, children: _jsx(ListItem, { text: {
+                    }, children: _jsx(ListItem, { component: "div", text: {
                             title: option.title,
                             description: option === null || option === void 0 ? void 0 : option.description,
-                        }, sx: { '.MuiListItem-root': { p: 0 } }, avatar: { Icon: option.Icon } }) }, option.title))) })] }));
+                        }, sx: { '.MuiListItem-root': { p: 0 }, justifyContent: 'center' }, avatar: option.Icon && { Icon: option.Icon } }) }, option.title))) })] }));
 };

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -10,7 +10,7 @@ export const MenuList = ({ Icon = IconDotsVertical, options }) => {
     const anchorRef = useRef(null);
     const handleMenuOpen = () => setOpenMenu(true);
     const handleMenuClose = () => setOpenMenu(false);
-    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { py: 0, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
+    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { ul: { py: 0 }, '*': { whiteSpace: 'normal' } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
                         option.onClick();
                         handleMenuClose();
                     }, disabled: option.disabled, children: _jsx(ListItem, { component: "div", text: {

--- a/lib/components/Menu/MenuList.js
+++ b/lib/components/Menu/MenuList.js
@@ -1,0 +1,20 @@
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
+import { useRef, useState } from 'react';
+import { IconButton } from '@mui/material';
+import { IconDotsVertical } from '@tabler/icons-react';
+import Menu from './Menu';
+import MenuItem from './MenuItem';
+import ListItem from '../List/ListItem';
+export const MenuList = ({ Icon = IconDotsVertical, options }) => {
+    const [openMenu, setOpenMenu] = useState(false);
+    const anchorRef = useRef(null);
+    const handleMenuOpen = () => setOpenMenu(true);
+    const handleMenuClose = () => setOpenMenu(false);
+    return (_jsxs(_Fragment, { children: [_jsx(IconButton, { ref: anchorRef, onClick: handleMenuOpen, children: _jsx(Icon, {}) }), _jsx(Menu, { anchorEl: anchorRef.current, onClose: handleMenuClose, open: openMenu, sx: { '.MuiListItem-root': { p: 0 } }, children: options.map(option => (_jsx(MenuItem, { onClick: () => {
+                        option.onClick();
+                        handleMenuClose();
+                    }, children: _jsx(ListItem, { text: {
+                            title: option.title,
+                            description: option === null || option === void 0 ? void 0 : option.description,
+                        }, sx: { '.MuiListItem-root': { p: 0 } }, avatar: { Icon: option.Icon } }) }, option.title))) })] }));
+};

--- a/lib/components/posts/CreatePost.d.ts
+++ b/lib/components/posts/CreatePost.d.ts
@@ -9,6 +9,7 @@ export type CreatePostProps = {
     fullName: string;
     handlePost: SubmitHandler<FieldValues>;
     sx?: CardContainerProps['sx'];
+    existingPost?: FieldValues;
 };
 export declare const CreatePost: FC<CreatePostProps>;
 export default CreatePost;

--- a/lib/components/posts/CreatePost.d.ts
+++ b/lib/components/posts/CreatePost.d.ts
@@ -10,6 +10,7 @@ export type CreatePostProps = {
     handlePost: SubmitHandler<FieldValues>;
     sx?: CardContainerProps['sx'];
     existingPost?: FieldValues;
+    onCancel?: () => void;
 };
 export declare const CreatePost: FC<CreatePostProps>;
 export default CreatePost;

--- a/lib/components/posts/CreatePost.js
+++ b/lib/components/posts/CreatePost.js
@@ -35,6 +35,6 @@ export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingP
                             multiline: true,
                             minRows: 1,
                             placeholder: t('WRITE_SOMETHING'),
-                        } }), _jsx(LoadingButton, { variant: "primary", sx: { alignSelf: 'flex-end' }, onClick: submit, disabled: !form.watch('body'), loading: form.formState.isSubmitting, size: "large", children: t('PUBLISH') })] }) }) })));
+                        } }), _jsx(LoadingButton, { variant: "primary", sx: { alignSelf: 'flex-end' }, onClick: submit, disabled: !form.watch('body'), loading: form.formState.isSubmitting, size: "large", children: t(existingPost ? 'EDIT' : 'PUBLISH') })] }) }) })));
 };
 export default CreatePost;

--- a/lib/components/posts/CreatePost.js
+++ b/lib/components/posts/CreatePost.js
@@ -19,8 +19,8 @@ import { getInitials } from '../../utils/user';
 export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingPost, }) => {
     const { t } = useTranslation();
     const form = useForm({
-        defaultValues: existingPost || {
-            body: '',
+        defaultValues: {
+            body: (existingPost === null || existingPost === void 0 ? void 0 : existingPost.body) || '',
         },
     });
     const submit = form.handleSubmit((values) => __awaiter(void 0, void 0, void 0, function* () {

--- a/lib/components/posts/CreatePost.js
+++ b/lib/components/posts/CreatePost.js
@@ -16,7 +16,7 @@ import FormInputClassic from '../Input/FormInputClassic';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from './i18n';
 import { getInitials } from '../../utils/user';
-export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingPost, }) => {
+export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingPost, onCancel, }) => {
     const { t } = useTranslation();
     const form = useForm({
         defaultValues: {
@@ -35,6 +35,6 @@ export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingP
                             multiline: true,
                             minRows: 1,
                             placeholder: t('WRITE_SOMETHING'),
-                        } }), _jsx(LoadingButton, { variant: "primary", sx: { alignSelf: 'flex-end' }, onClick: submit, disabled: !form.watch('body'), loading: form.formState.isSubmitting, size: "large", children: t(existingPost ? 'EDIT' : 'PUBLISH') })] }) }) })));
+                        } }), _jsxs(Stack, { sx: { flexDirection: 'row', justifyContent: 'flex-end', gap: 2 }, children: [!!onCancel && (_jsx(LoadingButton, { variant: "secondary", onClick: onCancel, children: t('CANCEL') })), _jsx(LoadingButton, { variant: "primary", onClick: submit, disabled: !form.watch('body'), loading: form.formState.isSubmitting, size: "large", children: t(existingPost ? 'EDIT' : 'PUBLISH') })] })] }) }) })));
 };
 export default CreatePost;

--- a/lib/components/posts/CreatePost.js
+++ b/lib/components/posts/CreatePost.js
@@ -27,7 +27,7 @@ export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingP
         yield handlePost(values);
         form.reset();
     }));
-    return (_jsx(FormProvider, Object.assign({}, form, { children: _jsx(CardContainer, { fullWidth: true, sx: sx, children: _jsxs(Stack, { children: [_jsxs(Stack, { sx: { flexDirection: 'row', alignItems: 'center', gap: 1 }, children: [_jsx(Avatar, { src: profilePicture, text: getInitials(fullName) }), _jsx(Typography, { sx: { flex: 1 }, children: fullName })] }), _jsx(FormInputClassic, { name: "body", inputProps: {
+    return (_jsx(FormProvider, Object.assign({}, form, { children: _jsx(CardContainer, { fullWidth: true, sx: sx, padding: 24, children: _jsxs(Stack, { children: [_jsxs(Stack, { sx: { flexDirection: 'row', alignItems: 'center', gap: 1 }, children: [_jsx(Avatar, { src: profilePicture, text: getInitials(fullName) }), _jsx(Typography, { sx: { flex: 1 }, children: fullName })] }), _jsx(FormInputClassic, { name: "body", inputProps: {
                             sx: {
                                 mt: 2,
                                 mb: 1,

--- a/lib/components/posts/CreatePost.js
+++ b/lib/components/posts/CreatePost.js
@@ -16,10 +16,10 @@ import FormInputClassic from '../Input/FormInputClassic';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from './i18n';
 import { getInitials } from '../../utils/user';
-export const CreatePost = ({ profilePicture, fullName, handlePost, sx, }) => {
+export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingPost, }) => {
     const { t } = useTranslation();
     const form = useForm({
-        defaultValues: {
+        defaultValues: existingPost || {
             body: '',
         },
     });

--- a/lib/components/posts/CreatePost.js
+++ b/lib/components/posts/CreatePost.js
@@ -27,6 +27,9 @@ export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingP
         yield handlePost(values);
         form.reset();
     }));
+    const { formState } = form;
+    const isValidPost = !!form.watch('body').trim() &&
+        (!existingPost || formState.dirtyFields.body);
     return (_jsx(FormProvider, Object.assign({}, form, { children: _jsx(CardContainer, { fullWidth: true, sx: sx, padding: 24, children: _jsxs(Stack, { children: [_jsxs(Stack, { sx: { flexDirection: 'row', alignItems: 'center', gap: 1 }, children: [_jsx(Avatar, { src: profilePicture, text: getInitials(fullName) }), _jsx(Typography, { sx: { flex: 1 }, children: fullName })] }), _jsx(FormInputClassic, { name: "body", inputProps: {
                             sx: {
                                 mt: 2,
@@ -35,6 +38,6 @@ export const CreatePost = ({ profilePicture, fullName, handlePost, sx, existingP
                             multiline: true,
                             minRows: 1,
                             placeholder: t('WRITE_SOMETHING'),
-                        } }), _jsxs(Stack, { sx: { flexDirection: 'row', justifyContent: 'flex-end', gap: 2 }, children: [!!onCancel && (_jsx(LoadingButton, { variant: "secondary", onClick: onCancel, children: t('CANCEL') })), _jsx(LoadingButton, { variant: "primary", onClick: submit, disabled: !form.watch('body'), loading: form.formState.isSubmitting, size: "large", children: t(existingPost ? 'EDIT' : 'PUBLISH') })] })] }) }) })));
+                        } }), _jsxs(Stack, { sx: { flexDirection: 'row', justifyContent: 'flex-end', gap: 2 }, children: [!!onCancel && (_jsx(LoadingButton, { variant: "secondary", onClick: onCancel, children: t('CANCEL') })), _jsx(LoadingButton, { variant: "primary", onClick: submit, disabled: !isValidPost, loading: formState.isSubmitting, size: "large", children: t(existingPost ? 'EDIT' : 'PUBLISH') })] })] }) }) })));
 };
 export default CreatePost;

--- a/lib/components/posts/Post.d.ts
+++ b/lib/components/posts/Post.d.ts
@@ -6,6 +6,10 @@ export type PostProps = {
     body: string;
     publicationDatetime: string;
     sx?: CardContainerProps['sx'];
+    actions?: {
+        onEdit: () => void;
+        onDelete: () => void;
+    };
 };
 export declare const Post: FC<PostProps>;
 export default Post;

--- a/lib/components/posts/Post.d.ts
+++ b/lib/components/posts/Post.d.ts
@@ -7,8 +7,8 @@ export type PostProps = {
     publicationDatetime: string;
     sx?: CardContainerProps['sx'];
     actions?: {
-        onEdit: () => void;
-        onDelete: () => void;
+        onEdit?: () => void;
+        onDelete?: () => void;
     };
 };
 export declare const Post: FC<PostProps>;

--- a/lib/components/posts/Post.js
+++ b/lib/components/posts/Post.js
@@ -28,6 +28,6 @@ export const Post = ({ profilePicture, fullName, body, publicationDatetime, sx, 
                         description: t('TIME_DISTANCE', {
                             distance: getDistanceToNow(publicationDatetime),
                         }),
-                    }, actionMenuList: actions ? (_jsx(MenuList, { Icon: IconDots, options: actionsList })) : undefined, sx: { '.MuiListItem-root': { p: 0 } } }), _jsx(SeeMoreText, { text: body, lines: 6 })] }) }));
+                    }, actionMenuList: actionsList.length ? (_jsx(MenuList, { Icon: IconDots, options: actionsList })) : undefined, sx: { '.MuiListItem-root': { p: 0 } } }), _jsx(SeeMoreText, { text: body, lines: 6 })] }) }));
 };
 export default Post;

--- a/lib/components/posts/Post.js
+++ b/lib/components/posts/Post.js
@@ -8,23 +8,26 @@ import { getDistanceToNow } from '../../utils/time';
 import { useTranslation } from './i18n';
 import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
 import { MenuList } from '../Menu/MenuList';
+import { insertIf } from '../../utils/array';
 export const Post = ({ profilePicture, fullName, body, publicationDatetime, sx, actions, }) => {
     const { t } = useTranslation();
-    const editAction = {
-        title: t('EDIT'),
-        Icon: IconEdit,
-        onClick: actions === null || actions === void 0 ? void 0 : actions.onEdit,
-    };
-    const deleteAction = {
-        title: t('DELETE'),
-        Icon: IconTrash,
-        onClick: actions === null || actions === void 0 ? void 0 : actions.onDelete,
-    };
+    const actionsList = [
+        ...insertIf(!!(actions === null || actions === void 0 ? void 0 : actions.onEdit), {
+            title: t('EDIT'),
+            Icon: IconEdit,
+            onClick: actions.onEdit,
+        }),
+        ...insertIf(!!(actions === null || actions === void 0 ? void 0 : actions.onDelete), {
+            title: t('DELETE'),
+            Icon: IconTrash,
+            onClick: actions.onDelete,
+        }),
+    ];
     return (_jsx(CardContainer, { fullWidth: true, padding: 24, sx: sx, children: _jsxs(Stack, { sx: { gap: 2 }, children: [_jsx(ListItem, { avatar: { src: profilePicture, text: getInitials(fullName) }, text: {
                         title: fullName,
                         description: t('TIME_DISTANCE', {
                             distance: getDistanceToNow(publicationDatetime),
                         }),
-                    }, actionMenuList: actions ? (_jsx(MenuList, { Icon: IconDots, options: [editAction, deleteAction] })) : undefined, sx: { '.MuiListItem-root': { p: 0 } } }), _jsx(SeeMoreText, { text: body, lines: 6 })] }) }));
+                    }, actionMenuList: actions ? (_jsx(MenuList, { Icon: IconDots, options: actionsList })) : undefined, sx: { '.MuiListItem-root': { p: 0 } } }), _jsx(SeeMoreText, { text: body, lines: 6 })] }) }));
 };
 export default Post;

--- a/lib/components/posts/Post.js
+++ b/lib/components/posts/Post.js
@@ -6,13 +6,25 @@ import SeeMoreText from '../SeeMoreText/SeeMoreText';
 import ListItem from '../List/ListItem';
 import { getDistanceToNow } from '../../utils/time';
 import { useTranslation } from './i18n';
-export const Post = ({ profilePicture, fullName, body, publicationDatetime, sx, }) => {
+import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
+import { MenuList } from '../Menu/MenuList';
+export const Post = ({ profilePicture, fullName, body, publicationDatetime, sx, actions, }) => {
     const { t } = useTranslation();
+    const editAction = {
+        title: t('EDIT'),
+        Icon: IconEdit,
+        onClick: actions === null || actions === void 0 ? void 0 : actions.onEdit,
+    };
+    const deleteAction = {
+        title: t('DELETE'),
+        Icon: IconTrash,
+        onClick: actions === null || actions === void 0 ? void 0 : actions.onDelete,
+    };
     return (_jsx(CardContainer, { fullWidth: true, padding: 24, sx: sx, children: _jsxs(Stack, { sx: { gap: 2 }, children: [_jsx(ListItem, { avatar: { src: profilePicture, text: getInitials(fullName) }, text: {
                         title: fullName,
                         description: t('TIME_DISTANCE', {
                             distance: getDistanceToNow(publicationDatetime),
                         }),
-                    }, sx: { '.MuiListItem-root': { p: 0 } } }), _jsx(SeeMoreText, { text: body, lines: 6 })] }) }));
+                    }, actionMenuList: actions ? (_jsx(MenuList, { Icon: IconDots, options: [editAction, deleteAction] })) : undefined, sx: { '.MuiListItem-root': { p: 0 } } }), _jsx(SeeMoreText, { text: body, lines: 6 })] }) }));
 };
 export default Post;

--- a/lib/components/posts/i18n.js
+++ b/lib/components/posts/i18n.js
@@ -9,6 +9,7 @@ initializeCheck(() => {
         TIME_DISTANCE: 'Hace {{distance}}',
         EDIT: 'Editar',
         DELETE: 'Eliminar',
+        CANCEL: 'Cancelar',
     });
     i18next.addResources('en', NAMESPACE, {
         PUBLISH: 'Publish',
@@ -16,6 +17,7 @@ initializeCheck(() => {
         TIME_DISTANCE: '{{distance}} ago',
         EDIT: 'Edit',
         DELETE: 'Delete',
+        CANCEL: 'Cancel',
     });
     i18next.addResources('pt', NAMESPACE, {
         PUBLISH: 'Publicar',
@@ -23,6 +25,7 @@ initializeCheck(() => {
         TIME_DISTANCE: 'Há {{distance}}',
         EDIT: 'Editar',
         DELETE: 'Excluir',
+        CANCEL: 'Cancelar',
     });
     i18next.addResources('de', NAMESPACE, {
         PUBLISH: 'Veröffentlichen',
@@ -30,6 +33,7 @@ initializeCheck(() => {
         TIME_DISTANCE: 'Vor {{distance}}',
         EDIT: 'Bearbeiten',
         DELETE: 'Löschen',
+        CANCEL: 'Stornieren',
     });
 });
 export const useTranslation = () => usei18nextTranslation(NAMESPACE);

--- a/lib/components/posts/i18n.js
+++ b/lib/components/posts/i18n.js
@@ -7,21 +7,29 @@ initializeCheck(() => {
         PUBLISH: 'Publicar',
         WRITE_SOMETHING: 'Escribe algo...',
         TIME_DISTANCE: 'Hace {{distance}}',
+        EDIT: 'Editar',
+        DELETE: 'Eliminar',
     });
     i18next.addResources('en', NAMESPACE, {
         PUBLISH: 'Publish',
         WRITE_SOMETHING: 'Write something...',
         TIME_DISTANCE: '{{distance}} ago',
+        EDIT: 'Edit',
+        DELETE: 'Delete',
     });
     i18next.addResources('pt', NAMESPACE, {
         PUBLISH: 'Publicar',
         WRITE_SOMETHING: 'Escreva algo...',
         TIME_DISTANCE: 'Há {{distance}}',
+        EDIT: 'Editar',
+        DELETE: 'Excluir',
     });
     i18next.addResources('de', NAMESPACE, {
         PUBLISH: 'Veröffentlichen',
         WRITE_SOMETHING: 'Schreibe etwas...',
         TIME_DISTANCE: 'Vor {{distance}}',
+        EDIT: 'Bearbeiten',
+        DELETE: 'Löschen',
     });
 });
 export const useTranslation = () => usei18nextTranslation(NAMESPACE);

--- a/lib/huexports.d.ts
+++ b/lib/huexports.d.ts
@@ -33,6 +33,7 @@ export { default as HuFormCheckbox } from './components/Checkbox/FormCheckbox';
 export { default as HuTooltip } from './components/Tooltip/Tooltip';
 export { default as HuMenu } from './components/Menu/Menu';
 export { default as HuMenuItem } from './components/Menu/MenuItem';
+export { default as HuMenuList } from './components/Menu/MenuList';
 export { default as HuAccordion } from './components/Accordion/Accordion';
 export { default as HuRadioButton } from './components/RadioButton/RadioButton';
 export { default as HuFormRadioButton } from './components/RadioButton/FormRadioButton';

--- a/lib/huexports.js
+++ b/lib/huexports.js
@@ -33,6 +33,7 @@ export { default as HuFormCheckbox } from './components/Checkbox/FormCheckbox';
 export { default as HuTooltip } from './components/Tooltip/Tooltip';
 export { default as HuMenu } from './components/Menu/Menu';
 export { default as HuMenuItem } from './components/Menu/MenuItem';
+export { default as HuMenuList } from './components/Menu/MenuList';
 export { default as HuAccordion } from './components/Accordion/Accordion';
 export { default as HuRadioButton } from './components/RadioButton/RadioButton';
 export { default as HuFormRadioButton } from './components/RadioButton/FormRadioButton';

--- a/lib/utils/array.d.ts
+++ b/lib/utils/array.d.ts
@@ -1,0 +1,1 @@
+export declare const insertIf: <T>(condition: boolean, element: T) => T[];

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -1,0 +1,1 @@
+export const insertIf = (condition, element) => condition ? [element] : [];

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -14,7 +14,10 @@ import { Title, TitleProps } from '../Title/Title';
 import { Avatar, AvatarProps } from '../Avatar/Avatar';
 import { TablerIcon } from '@tabler/icons-react';
 
-type ContainerProps = Pick<MuiLisItemProps, 'children' | 'divider' | 'sx'>;
+type ContainerProps = Pick<
+  MuiLisItemProps,
+  'children' | 'divider' | 'sx' | 'component'
+>;
 
 export type ListItemProps = Omit<ContainerProps, 'children' | 'sx'> &
   Pick<StackProps, 'id' | 'sx'> & {
@@ -43,6 +46,7 @@ export const ListItem: FC<ListItemProps> = ({
   actionMenuList,
   divider,
   sideContent,
+  component,
 }) => {
   const Container = onClick
     ? (props: ContainerProps) => (
@@ -72,6 +76,7 @@ export const ListItem: FC<ListItemProps> = ({
       {loading && <ListItemSkeleton />}
       {!loading && (
         <Container
+          component={component}
           sx={{
             p: 2,
             gap: 0.5,

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -28,6 +28,7 @@ export type ListItemProps = Omit<ContainerProps, 'children' | 'sx'> &
     > & {
       Icon: TablerIcon;
     };
+    actionMenuList?: ReactNode;
     sideContent?: ReactNode;
   };
 
@@ -39,6 +40,7 @@ export const ListItem: FC<ListItemProps> = ({
   text,
   avatar,
   action,
+  actionMenuList,
   divider,
   sideContent,
 }) => {
@@ -119,6 +121,7 @@ export const ListItem: FC<ListItemProps> = ({
                 {ActionIcon && <ActionIcon size={24} />}
               </MuiIconButton>
             )}
+            {actionMenuList}
           </Stack>
         </Container>
       )}

--- a/src/components/Menu/MenuList.stories.tsx
+++ b/src/components/Menu/MenuList.stories.tsx
@@ -12,8 +12,13 @@ const defaultOptions = [
     title: 'Eliminar',
   },
   { Icon: IconEye, title: 'Ver detalle', description: 'Descripción' },
-  { title: 'Sin ícono ni descripción' },
-  { title: 'Sin ícono', description: 'Descripción' },
+  { title: 'Sin icono ni descripción' },
+  { title: 'Sin icono', description: 'Descripción' },
+  { title: 'Sin icono ni descripción pero muchísimo más largo' },
+  {
+    title: 'Sin icono pero muchísimo más largo',
+    description: 'Descripción pero muchísimo más larga',
+  },
 ].map(o => ({ ...o, onClick: () => alert(o.title) }));
 
 const meta: Meta<typeof MenuList> = {

--- a/src/components/Menu/MenuList.stories.tsx
+++ b/src/components/Menu/MenuList.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconEdit, IconEye, IconTrash } from '@tabler/icons-react';
+import { MenuList } from './MenuList';
+
+const defaultOptions = [
+  {
+    Icon: IconEdit,
+    title: 'Editar',
+  },
+  {
+    Icon: IconTrash,
+    title: 'Eliminar',
+  },
+  { Icon: IconEye, title: 'Ver detalle', description: 'Descripción' },
+].map(o => ({ ...o, onClick: () => alert(o.title) }));
+
+const meta: Meta<typeof MenuList> = {
+  component: MenuList,
+  title: 'MenuList',
+  tags: ['autodocs'],
+  args: {
+    options: defaultOptions,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MenuList>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/Menu/MenuList.stories.tsx
+++ b/src/components/Menu/MenuList.stories.tsx
@@ -12,6 +12,8 @@ const defaultOptions = [
     title: 'Eliminar',
   },
   { Icon: IconEye, title: 'Ver detalle', description: 'Descripción' },
+  { title: 'Sin ícono ni descripción' },
+  { title: 'Sin ícono', description: 'Descripción' },
 ].map(o => ({ ...o, onClick: () => alert(o.title) }));
 
 const meta: Meta<typeof MenuList> = {

--- a/src/components/Menu/MenuList.stories.tsx
+++ b/src/components/Menu/MenuList.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { IconEdit, IconEye, IconTrash } from '@tabler/icons-react';
 import { MenuList } from './MenuList';
+import { Button } from '@mui/material';
 
 const defaultOptions = [
   {
@@ -42,4 +43,24 @@ type Story = StoryObj<typeof MenuList>;
 
 export const Default: Story = {
   args: {},
+};
+
+export const WithCustomButton: Story = {
+  args: {
+    customButton: <Button variant="secondary">Soy un boton custom!</Button>,
+  },
+};
+
+export const WithDisabledCustomButton: Story = {
+  args: {
+    customButton: (
+      <Button
+        disabled
+        variant="secondary"
+      >
+        Soy un boton custom deshabilitado :(
+      </Button>
+    ),
+    disableMenu: true,
+  },
 };

--- a/src/components/Menu/MenuList.stories.tsx
+++ b/src/components/Menu/MenuList.stories.tsx
@@ -19,6 +19,12 @@ const defaultOptions = [
     title: 'Sin icono pero muchísimo más largo',
     description: 'Descripción pero muchísimo más larga',
   },
+  {
+    Icon: IconEye,
+    title: 'Disabled',
+    description: 'Disabled',
+    disabled: true,
+  },
 ].map(o => ({ ...o, onClick: () => alert(o.title) }));
 
 const meta: Meta<typeof MenuList> = {

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -1,0 +1,59 @@
+import { FC, useRef, useState } from 'react';
+import { IconButton } from '@mui/material';
+import { IconDotsVertical } from '@tabler/icons-react';
+import Menu from './Menu';
+import MenuItem from './MenuItem';
+import ListItem from '../List/ListItem';
+
+type Props = {
+  Icon?: typeof IconDotsVertical;
+  options: {
+    Icon?: any;
+    title: string;
+    description?: string;
+    onClick: () => void;
+  }[];
+};
+
+export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
+  const [openMenu, setOpenMenu] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const handleMenuOpen = () => setOpenMenu(true);
+  const handleMenuClose = () => setOpenMenu(false);
+
+  return (
+    <>
+      <IconButton
+        ref={anchorRef}
+        onClick={handleMenuOpen}
+      >
+        <Icon />
+      </IconButton>
+      <Menu
+        anchorEl={anchorRef.current}
+        onClose={handleMenuClose}
+        open={openMenu}
+        sx={{ '.MuiListItem-root': { p: 0 } }}
+      >
+        {options.map(option => (
+          <MenuItem
+            key={option.title}
+            onClick={() => {
+              option.onClick();
+              handleMenuClose();
+            }}
+          >
+            <ListItem
+              text={{
+                title: option.title,
+                description: option?.description,
+              }}
+              sx={{ '.MuiListItem-root': { p: 0 } }}
+              avatar={{ Icon: option.Icon }}
+            />
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -34,7 +34,7 @@ export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
         anchorEl={anchorRef.current}
         onClose={handleMenuClose}
         open={openMenu}
-        sx={{ py: 0, '*': { whiteSpace: 'normal' } }}
+        sx={{ ul: { py: 0 }, '*': { whiteSpace: 'normal' } }}
       >
         {options.map(option => (
           <MenuItem

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -1,5 +1,5 @@
-import { FC, useRef, useState } from 'react';
-import { IconButton } from '@mui/material';
+import { FC, ReactNode, useRef, useState } from 'react';
+import { IconButton, Stack } from '@mui/material';
 import { IconDotsVertical } from '@tabler/icons-react';
 import Menu from './Menu';
 import MenuItem from './MenuItem';
@@ -14,22 +14,37 @@ type Props = {
     onClick: () => void;
     disabled?: boolean;
   }[];
+  customButton?: ReactNode;
 };
 
-export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
+export const MenuList: FC<Props> = ({
+  Icon = IconDotsVertical,
+  options,
+  customButton,
+}) => {
   const [openMenu, setOpenMenu] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const anchorRef = useRef(null);
   const handleMenuOpen = () => setOpenMenu(true);
   const handleMenuClose = () => setOpenMenu(false);
 
   return (
     <>
-      <IconButton
-        ref={anchorRef}
-        onClick={handleMenuOpen}
-      >
-        <Icon />
-      </IconButton>
+      {!!customButton && (
+        <Stack
+          ref={anchorRef}
+          onClick={handleMenuOpen}
+        >
+          {customButton}
+        </Stack>
+      )}
+      {!customButton && (
+        <IconButton
+          ref={anchorRef}
+          onClick={handleMenuOpen}
+        >
+          <Icon />
+        </IconButton>
+      )}
       <Menu
         anchorEl={anchorRef.current}
         onClose={handleMenuClose}

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -1,5 +1,5 @@
-import { FC, ReactNode, useRef, useState } from 'react';
-import { IconButton, Stack } from '@mui/material';
+import { cloneElement, FC, ReactElement, useRef, useState } from 'react';
+import { IconButton } from '@mui/material';
 import { IconDotsVertical } from '@tabler/icons-react';
 import Menu from './Menu';
 import MenuItem from './MenuItem';
@@ -14,13 +14,15 @@ type Props = {
     onClick: () => void;
     disabled?: boolean;
   }[];
-  customButton?: ReactNode;
+  customButton?: ReactElement;
+  disableMenu?: boolean;
 };
 
 export const MenuList: FC<Props> = ({
   Icon = IconDotsVertical,
   options,
   customButton,
+  disableMenu,
 }) => {
   const [openMenu, setOpenMenu] = useState(false);
   const anchorRef = useRef(null);
@@ -29,14 +31,11 @@ export const MenuList: FC<Props> = ({
 
   return (
     <>
-      {!!customButton && (
-        <Stack
-          ref={anchorRef}
-          onClick={handleMenuOpen}
-        >
-          {customButton}
-        </Stack>
-      )}
+      {!!customButton &&
+        cloneElement(customButton, {
+          ref: anchorRef,
+          onClick: disableMenu ? undefined : handleMenuOpen,
+        })}
       {!customButton && (
         <IconButton
           ref={anchorRef}

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -12,6 +12,7 @@ type Props = {
     title: string;
     description?: string;
     onClick: () => void;
+    disabled?: boolean;
   }[];
 };
 
@@ -42,6 +43,7 @@ export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
               option.onClick();
               handleMenuClose();
             }}
+            disabled={option.disabled}
           >
             <ListItem
               component="div"

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -58,3 +58,5 @@ export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
     </>
   );
 };
+
+export default MenuList;

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -33,7 +33,7 @@ export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
         anchorEl={anchorRef.current}
         onClose={handleMenuClose}
         open={openMenu}
-        sx={{ '.MuiListItem-root': { p: 0 } }}
+        sx={{ py: 0 }}
       >
         {options.map(option => (
           <MenuItem
@@ -44,12 +44,13 @@ export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
             }}
           >
             <ListItem
+              component="div"
               text={{
                 title: option.title,
                 description: option?.description,
               }}
-              sx={{ '.MuiListItem-root': { p: 0 } }}
-              avatar={{ Icon: option.Icon }}
+              sx={{ '.MuiListItem-root': { p: 0 }, justifyContent: 'center' }}
+              avatar={option.Icon && { Icon: option.Icon }}
             />
           </MenuItem>
         ))}

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -33,7 +33,7 @@ export const MenuList: FC<Props> = ({ Icon = IconDotsVertical, options }) => {
         anchorEl={anchorRef.current}
         onClose={handleMenuClose}
         open={openMenu}
-        sx={{ py: 0 }}
+        sx={{ py: 0, '*': { whiteSpace: 'normal' } }}
       >
         {options.map(option => (
           <MenuItem

--- a/src/components/posts/CreatePost.stories.tsx
+++ b/src/components/posts/CreatePost.stories.tsx
@@ -18,3 +18,9 @@ type Story = StoryObj<typeof CreatePost>;
 export const Default: Story = {
   args: {},
 };
+
+export const EditPost: Story = {
+  args: {
+    existingPost: { body: 'This is the original post text' },
+  },
+};

--- a/src/components/posts/CreatePost.stories.tsx
+++ b/src/components/posts/CreatePost.stories.tsx
@@ -22,5 +22,6 @@ export const Default: Story = {
 export const EditPost: Story = {
   args: {
     existingPost: { body: 'This is the original post text' },
+    onCancel: () => alert('CancelButtonClicked'),
   },
 };

--- a/src/components/posts/CreatePost.tsx
+++ b/src/components/posts/CreatePost.tsx
@@ -32,8 +32,8 @@ export const CreatePost: FC<CreatePostProps> = ({
   const { t } = useTranslation();
 
   const form = useForm<FieldValues>({
-    defaultValues: existingPost || {
-      body: '',
+    defaultValues: {
+      body: existingPost?.body || '',
     },
   });
 

--- a/src/components/posts/CreatePost.tsx
+++ b/src/components/posts/CreatePost.tsx
@@ -19,6 +19,7 @@ export type CreatePostProps = {
   fullName: string;
   handlePost: SubmitHandler<FieldValues>;
   sx?: CardContainerProps['sx'];
+  existingPost?: FieldValues;
 };
 
 export const CreatePost: FC<CreatePostProps> = ({
@@ -26,11 +27,12 @@ export const CreatePost: FC<CreatePostProps> = ({
   fullName,
   handlePost,
   sx,
+  existingPost,
 }) => {
   const { t } = useTranslation();
 
   const form = useForm<FieldValues>({
-    defaultValues: {
+    defaultValues: existingPost || {
       body: '',
     },
   });

--- a/src/components/posts/CreatePost.tsx
+++ b/src/components/posts/CreatePost.tsx
@@ -43,6 +43,11 @@ export const CreatePost: FC<CreatePostProps> = ({
     await handlePost(values);
     form.reset();
   });
+  const { formState } = form;
+
+  const isValidPost =
+    !!form.watch('body').trim() &&
+    (!existingPost || formState.dirtyFields.body);
 
   return (
     <FormProvider {...form}>
@@ -85,8 +90,8 @@ export const CreatePost: FC<CreatePostProps> = ({
             <LoadingButton
               variant="primary"
               onClick={submit}
-              disabled={!form.watch('body')}
-              loading={form.formState.isSubmitting}
+              disabled={!isValidPost}
+              loading={formState.isSubmitting}
               size="large"
             >
               {t(existingPost ? 'EDIT' : 'PUBLISH')}

--- a/src/components/posts/CreatePost.tsx
+++ b/src/components/posts/CreatePost.tsx
@@ -77,7 +77,7 @@ export const CreatePost: FC<CreatePostProps> = ({
             loading={form.formState.isSubmitting}
             size="large"
           >
-            {t('PUBLISH')}
+            {t(existingPost ? 'EDIT' : 'PUBLISH')}
           </LoadingButton>
         </Stack>
       </CardContainer>

--- a/src/components/posts/CreatePost.tsx
+++ b/src/components/posts/CreatePost.tsx
@@ -47,6 +47,7 @@ export const CreatePost: FC<CreatePostProps> = ({
       <CardContainer
         fullWidth
         sx={sx}
+        padding={24}
       >
         <Stack>
           <Stack sx={{ flexDirection: 'row', alignItems: 'center', gap: 1 }}>

--- a/src/components/posts/CreatePost.tsx
+++ b/src/components/posts/CreatePost.tsx
@@ -20,6 +20,7 @@ export type CreatePostProps = {
   handlePost: SubmitHandler<FieldValues>;
   sx?: CardContainerProps['sx'];
   existingPost?: FieldValues;
+  onCancel?: () => void;
 };
 
 export const CreatePost: FC<CreatePostProps> = ({
@@ -28,6 +29,7 @@ export const CreatePost: FC<CreatePostProps> = ({
   handlePost,
   sx,
   existingPost,
+  onCancel,
 }) => {
   const { t } = useTranslation();
 
@@ -69,16 +71,27 @@ export const CreatePost: FC<CreatePostProps> = ({
               placeholder: t('WRITE_SOMETHING'),
             }}
           />
-          <LoadingButton
-            variant="primary"
-            sx={{ alignSelf: 'flex-end' }}
-            onClick={submit}
-            disabled={!form.watch('body')}
-            loading={form.formState.isSubmitting}
-            size="large"
+          <Stack
+            sx={{ flexDirection: 'row', justifyContent: 'flex-end', gap: 2 }}
           >
-            {t(existingPost ? 'EDIT' : 'PUBLISH')}
-          </LoadingButton>
+            {!!onCancel && (
+              <LoadingButton
+                variant="secondary"
+                onClick={onCancel}
+              >
+                {t('CANCEL')}
+              </LoadingButton>
+            )}
+            <LoadingButton
+              variant="primary"
+              onClick={submit}
+              disabled={!form.watch('body')}
+              loading={form.formState.isSubmitting}
+              size="large"
+            >
+              {t(existingPost ? 'EDIT' : 'PUBLISH')}
+            </LoadingButton>
+          </Stack>
         </Stack>
       </CardContainer>
     </FormProvider>

--- a/src/components/posts/Post.stories.tsx
+++ b/src/components/posts/Post.stories.tsx
@@ -22,3 +22,12 @@ type Story = StoryObj<typeof Post>;
 export const Default: Story = {
   args: {},
 };
+
+export const ActionablePost: Story = {
+  args: {
+    actions: {
+      onEdit: () => alert('Edit'),
+      onDelete: () => alert('Delete'),
+    },
+  },
+};

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -10,6 +10,7 @@ import { getDistanceToNow } from '../../utils/time';
 import { useTranslation } from './i18n';
 import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
 import { MenuList } from '../Menu/MenuList';
+import { insertIf } from '../../utils/array';
 
 export type PostProps = {
   profilePicture?: string;
@@ -18,8 +19,8 @@ export type PostProps = {
   publicationDatetime: string;
   sx?: CardContainerProps['sx'];
   actions?: {
-    onEdit: () => void;
-    onDelete: () => void;
+    onEdit?: () => void;
+    onDelete?: () => void;
   };
 };
 
@@ -33,17 +34,18 @@ export const Post: FC<PostProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const editAction = {
-    title: t('EDIT'),
-    Icon: IconEdit,
-    onClick: actions?.onEdit!,
-  };
-
-  const deleteAction = {
-    title: t('DELETE'),
-    Icon: IconTrash,
-    onClick: actions?.onDelete!,
-  };
+  const actionsList = [
+    ...insertIf(!!actions?.onEdit, {
+      title: t('EDIT'),
+      Icon: IconEdit,
+      onClick: actions!.onEdit!,
+    }),
+    ...insertIf(!!actions?.onDelete, {
+      title: t('DELETE'),
+      Icon: IconTrash,
+      onClick: actions!.onDelete!,
+    }),
+  ];
 
   return (
     <CardContainer
@@ -64,7 +66,7 @@ export const Post: FC<PostProps> = ({
             actions ? (
               <MenuList
                 Icon={IconDots}
-                options={[editAction, deleteAction]}
+                options={actionsList}
               />
             ) : undefined
           }

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -63,7 +63,7 @@ export const Post: FC<PostProps> = ({
             }),
           }}
           actionMenuList={
-            actions ? (
+            actionsList.length ? (
               <MenuList
                 Icon={IconDots}
                 options={actionsList}

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -8,7 +8,8 @@ import SeeMoreText from '../SeeMoreText/SeeMoreText';
 import ListItem from '../List/ListItem';
 import { getDistanceToNow } from '../../utils/time';
 import { useTranslation } from './i18n';
-import { IconDots } from '@tabler/icons-react';
+import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
+import { MenuList } from '../Menu/MenuList';
 
 export type PostProps = {
   profilePicture?: string;
@@ -16,7 +17,10 @@ export type PostProps = {
   body: string;
   publicationDatetime: string;
   sx?: CardContainerProps['sx'];
-  showActions?: boolean;
+  actions?: {
+    onEdit: () => void;
+    onDelete: () => void;
+  };
 };
 
 export const Post: FC<PostProps> = ({
@@ -25,9 +29,22 @@ export const Post: FC<PostProps> = ({
   body,
   publicationDatetime,
   sx,
-  showActions,
+  actions,
 }) => {
   const { t } = useTranslation();
+
+  const editAction = {
+    title: t('EDIT'),
+    Icon: IconEdit,
+    onClick: actions?.onEdit!,
+  };
+
+  const deleteAction = {
+    title: t('DELETE'),
+    Icon: IconTrash,
+    onClick: actions?.onDelete!,
+  };
+
   return (
     <CardContainer
       fullWidth
@@ -43,7 +60,14 @@ export const Post: FC<PostProps> = ({
               distance: getDistanceToNow(publicationDatetime),
             }),
           }}
-          action={showActions ? { Icon: IconDots, color: 'red' } : undefined}
+          actionMenuList={
+            actions ? (
+              <MenuList
+                Icon={IconDots}
+                options={[editAction, deleteAction]}
+              />
+            ) : undefined
+          }
           sx={{ '.MuiListItem-root': { p: 0 } }}
         />
         <SeeMoreText

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -8,6 +8,7 @@ import SeeMoreText from '../SeeMoreText/SeeMoreText';
 import ListItem from '../List/ListItem';
 import { getDistanceToNow } from '../../utils/time';
 import { useTranslation } from './i18n';
+import { IconDots } from '@tabler/icons-react';
 
 export type PostProps = {
   profilePicture?: string;
@@ -15,6 +16,7 @@ export type PostProps = {
   body: string;
   publicationDatetime: string;
   sx?: CardContainerProps['sx'];
+  showActions?: boolean;
 };
 
 export const Post: FC<PostProps> = ({
@@ -23,6 +25,7 @@ export const Post: FC<PostProps> = ({
   body,
   publicationDatetime,
   sx,
+  showActions,
 }) => {
   const { t } = useTranslation();
   return (
@@ -40,6 +43,7 @@ export const Post: FC<PostProps> = ({
               distance: getDistanceToNow(publicationDatetime),
             }),
           }}
+          action={showActions ? { Icon: IconDots, color: 'red' } : undefined}
           sx={{ '.MuiListItem-root': { p: 0 } }}
         />
         <SeeMoreText

--- a/src/components/posts/i18n.ts
+++ b/src/components/posts/i18n.ts
@@ -11,6 +11,7 @@ initializeCheck(() => {
     TIME_DISTANCE: 'Hace {{distance}}',
     EDIT: 'Editar',
     DELETE: 'Eliminar',
+    CANCEL: 'Cancelar',
   });
 
   i18next.addResources('en', NAMESPACE, {
@@ -19,6 +20,7 @@ initializeCheck(() => {
     TIME_DISTANCE: '{{distance}} ago',
     EDIT: 'Edit',
     DELETE: 'Delete',
+    CANCEL: 'Cancel',
   });
 
   i18next.addResources('pt', NAMESPACE, {
@@ -27,6 +29,7 @@ initializeCheck(() => {
     TIME_DISTANCE: 'Há {{distance}}',
     EDIT: 'Editar',
     DELETE: 'Excluir',
+    CANCEL: 'Cancelar',
   });
 
   i18next.addResources('de', NAMESPACE, {
@@ -35,6 +38,7 @@ initializeCheck(() => {
     TIME_DISTANCE: 'Vor {{distance}}',
     EDIT: 'Bearbeiten',
     DELETE: 'Löschen',
+    CANCEL: 'Stornieren',
   });
 });
 

--- a/src/components/posts/i18n.ts
+++ b/src/components/posts/i18n.ts
@@ -9,24 +9,32 @@ initializeCheck(() => {
     PUBLISH: 'Publicar',
     WRITE_SOMETHING: 'Escribe algo...',
     TIME_DISTANCE: 'Hace {{distance}}',
+    EDIT: 'Editar',
+    DELETE: 'Eliminar',
   });
 
   i18next.addResources('en', NAMESPACE, {
     PUBLISH: 'Publish',
     WRITE_SOMETHING: 'Write something...',
     TIME_DISTANCE: '{{distance}} ago',
+    EDIT: 'Edit',
+    DELETE: 'Delete',
   });
 
   i18next.addResources('pt', NAMESPACE, {
     PUBLISH: 'Publicar',
     WRITE_SOMETHING: 'Escreva algo...',
     TIME_DISTANCE: 'Há {{distance}}',
+    EDIT: 'Editar',
+    DELETE: 'Excluir',
   });
 
   i18next.addResources('de', NAMESPACE, {
     PUBLISH: 'Veröffentlichen',
     WRITE_SOMETHING: 'Schreibe etwas...',
     TIME_DISTANCE: 'Vor {{distance}}',
+    EDIT: 'Bearbeiten',
+    DELETE: 'Löschen',
   });
 });
 

--- a/src/huexports.ts
+++ b/src/huexports.ts
@@ -33,6 +33,7 @@ export { default as HuFormCheckbox } from './components/Checkbox/FormCheckbox';
 export { default as HuTooltip } from './components/Tooltip/Tooltip';
 export { default as HuMenu } from './components/Menu/Menu';
 export { default as HuMenuItem } from './components/Menu/MenuItem';
+export { default as HuMenuList } from './components/Menu/MenuList';
 export { default as HuAccordion } from './components/Accordion/Accordion';
 export { default as HuRadioButton } from './components/RadioButton/RadioButton';
 export { default as HuFormRadioButton } from './components/RadioButton/FormRadioButton';

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,2 @@
+export const insertIf = <T>(condition: boolean, element: T) =>
+  condition ? [element] : [];


### PR DESCRIPTION
## Summary
- AgregoMenuList
<img width="546" alt="image" src="https://github.com/user-attachments/assets/90ffcf71-c4ae-4c8b-8f68-be841cfe06fa" />

- Agrego al ListItem la opción de cambiarle el `component`. Esto es porque cuando lo usamos dentro de un MenuList -> MenuItem, lo estamos usando como descendiente de otro li y tira un error en consola.
- Agrego al ListItem action la opcion de mandar le action completa, para poder usarlo con MenuList. No me encanta este modo porque me parece más correcto para el DS pasarle la configuración y que el componente se encargue de renderizarlo bien. Pero para usarlo con MenuList necesito pasarle el boton ya renderizado y creo que eventualmente va a ser el caso más comun.
- Modifico el CreatePost para soportar edición y fixear estilos
